### PR TITLE
Change default application dependencies

### DIFF
--- a/builder/src/Gren/Outline.hs
+++ b/builder/src/Gren/Outline.hs
@@ -173,11 +173,9 @@ read root =
               if Map.notMember Pkg.core deps && pkg /= Pkg.core
                 then Left Exit.OutlineNoPkgCore
                 else Right outline
-          App (AppOutline _ srcDirs direct indirect _ _)
+          App (AppOutline _ srcDirs direct _ _ _)
             | Map.notMember Pkg.core direct ->
                 return $ Left Exit.OutlineNoAppCore
-            | Map.notMember Pkg.json direct && Map.notMember Pkg.json indirect ->
-                return $ Left Exit.OutlineNoAppJson
             | otherwise ->
                 do
                   badDirs <- filterM (isSrcDirMissing root) (NE.toList srcDirs)

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -1126,7 +1126,6 @@ data Outline
   | OutlineHasDuplicateSrcDirs FilePath FilePath FilePath
   | OutlineNoPkgCore
   | OutlineNoAppCore
-  | OutlineNoAppJson
 
 data OutlineProblem
   = OP_BadType
@@ -1212,17 +1211,6 @@ toOutlineReport problem =
         (Just "gren.json")
         "I need to see an \"gren-lang/core\" dependency your gren.json file. The default imports\
         \ of `List` and `Maybe` do not work without it."
-        [ D.reflow $
-            "If you modified your gren.json by hand, try to change it back! And if you are\
-            \ having trouble getting back to a working gren.json, it may be easier to delete it\
-            \ and use `gren init` to start fresh."
-        ]
-    OutlineNoAppJson ->
-      Help.report
-        "MISSING DEPENDENCY"
-        (Just "gren.json")
-        "I need to see an \"gren/json\" dependency your gren.json file. It helps me handle\
-        \ flags and ports."
         [ D.reflow $
             "If you modified your gren.json by hand, try to change it back! And if you are\
             \ having trouble getting back to a working gren.json, it may be easier to delete it\

--- a/terminal/src/Init.hs
+++ b/terminal/src/Init.hs
@@ -123,8 +123,7 @@ appDefaultDeps :: Map.Map Pkg.Name Con.Constraint
 appDefaultDeps =
   Map.fromList
     [ (Pkg.core, Con.anything),
-      (Pkg.browser, Con.anything),
-      (Pkg.html, Con.anything)
+      (Pkg.browser, Con.anything)
     ]
 
 pkgDefaultDeps :: Map.Map Pkg.Name Con.Constraint


### PR DESCRIPTION
For Gren 0.2.0, the `gren-lang/json` package is merged into `gren-lang/core`. The required dependency on `gren-lang/json` in packages can thus be removed.