### PR TITLE
Package manager improvements

### DIFF
--- a/builder/src/Deps/Package.hs
+++ b/builder/src/Deps/Package.hs
@@ -26,8 +26,8 @@ bumpPossibilities (latest, previous) =
   let allVersions = reverse (latest : previous)
       minorPoints = map last (List.groupBy sameMajor allVersions)
       patchPoints = map last (List.groupBy sameMinor allVersions)
-   in (latest, V.bumpMajor latest, M.MAJOR) :
-      map (\v -> (v, V.bumpMinor v, M.MINOR)) minorPoints
+   in (latest, V.bumpMajor latest, M.MAJOR)
+        : map (\v -> (v, V.bumpMinor v, M.MINOR)) minorPoints
         ++ map (\v -> (v, V.bumpPatch v, M.PATCH)) patchPoints
 
 sameMajor :: V.Version -> V.Version -> Bool

--- a/builder/src/Deps/Package.hs
+++ b/builder/src/Deps/Package.hs
@@ -106,8 +106,8 @@ bumpPossibilities (latest, previous) =
   let allVersions = reverse (latest : previous)
       minorPoints = map last (List.groupBy sameMajor allVersions)
       patchPoints = map last (List.groupBy sameMinor allVersions)
-   in (latest, V.bumpMajor latest, M.MAJOR) :
-      map (\v -> (v, V.bumpMinor v, M.MINOR)) minorPoints
+   in (latest, V.bumpMajor latest, M.MAJOR)
+        : map (\v -> (v, V.bumpMinor v, M.MINOR)) minorPoints
         ++ map (\v -> (v, V.bumpPatch v, M.PATCH)) patchPoints
 
 sameMajor :: V.Version -> V.Version -> Bool

--- a/builder/src/Deps/Package.hs
+++ b/builder/src/Deps/Package.hs
@@ -1,6 +1,6 @@
 module Deps.Package
   ( getVersions,
-    getLatestCompatibleVersion,
+    latestCompatibleVersion,
     latestCompatibleVersionForPackages,
     bumpPossibilities,
     installPackageVersion,
@@ -26,8 +26,8 @@ getVersions name =
 
 -- GET LATEST COMPATIBLE VERSION
 
-getLatestCompatibleVersion :: Dirs.PackageCache -> Pkg.Name -> IO (Either () V.Version)
-getLatestCompatibleVersion cache name = do
+latestCompatibleVersion :: Dirs.PackageCache -> Pkg.Name -> IO (Either () V.Version)
+latestCompatibleVersion cache name = do
   versionsResult <- getVersions name
   case versionsResult of
     Right (first, rest) ->
@@ -81,7 +81,7 @@ latestCompatibleVersionForPackagesHelp cache pkgs result =
   case pkgs of
     [] -> return $ Right result
     pkg : rest -> do
-      possibleVersion <- getLatestCompatibleVersion cache pkg
+      possibleVersion <- latestCompatibleVersion cache pkg
       case possibleVersion of
         Left _ ->
           return $ Left ()

--- a/builder/src/Deps/Solver.hs
+++ b/builder/src/Deps/Solver.hs
@@ -196,8 +196,8 @@ addConstraint solved unsolved (name, newConstraint) =
 
 getRelevantVersions :: Pkg.Name -> C.Constraint -> Solver (V.Version, [V.Version])
 getRelevantVersions name constraint =
-  Solver $ \state@(State cache _) ok back err -> do
-    versionsResult <- Package.getVersions cache name
+  Solver $ \state@(State _ _) ok back err -> do
+    versionsResult <- Package.getVersions name
     case versionsResult of
       Right (newest, previous) ->
         case filter (C.satisfies constraint) (newest : previous) of

--- a/builder/src/Deps/Solver.hs
+++ b/builder/src/Deps/Solver.hs
@@ -157,9 +157,8 @@ exploreGoals (Goals pending solved) =
     Just ((name, constraint), otherPending) ->
       do
         let goals1 = Goals otherPending solved
-        let addVsn = addVersion goals1 name
-        (v, vs) <- getRelevantVersions name constraint
-        goals2 <- oneOf (addVsn v) (map addVsn vs)
+        let lowestVersion = C.lowerBound constraint
+        goals2 <- addVersion goals1 name lowestVersion
         exploreGoals goals2
 
 addVersion :: Goals -> Pkg.Name -> V.Version -> Solver Goals
@@ -194,6 +193,7 @@ addConstraint solved unsolved (name, newConstraint) =
 
 -- GET RELEVANT VERSIONS
 
+{- TODO: do we still need this?
 getRelevantVersions :: Pkg.Name -> C.Constraint -> Solver (V.Version, [V.Version])
 getRelevantVersions name constraint =
   Solver $ \state@(State _ _) ok back err -> do
@@ -205,6 +205,7 @@ getRelevantVersions name constraint =
           v : vs -> ok state (v, vs) back
       Left gitErr ->
         err $ Exit.SolverBadGitOperationUnversionedPkg name gitErr
+        -}
 
 -- GET CONSTRAINTS
 

--- a/builder/src/Deps/Solver.hs
+++ b/builder/src/Deps/Solver.hs
@@ -90,21 +90,20 @@ data AppSolution = AppSolution
     _app :: Outline.AppOutline
   }
 
-addToApp :: Dirs.PackageCache -> Pkg.Name -> Outline.AppOutline -> IO (Result AppSolution)
-addToApp cache pkg outline@(Outline.AppOutline _ _ direct indirect testDirect testIndirect) =
+addToApp :: Dirs.PackageCache -> Pkg.Name -> V.Version -> Outline.AppOutline -> IO (Result AppSolution)
+addToApp cache pkg compatibleVsn outline@(Outline.AppOutline _ _ direct indirect testDirect testIndirect) =
   Dirs.withRegistryLock cache $
     let allIndirects = Map.union indirect testIndirect
         allDirects = Map.union direct testDirect
         allDeps = Map.union allDirects allIndirects
 
         attempt toConstraint deps =
-          try (Map.insert pkg C.anything (Map.map toConstraint deps))
+          try (Map.insert pkg (C.untilNextMajor compatibleVsn) (Map.map toConstraint deps))
      in case oneOf
           (attempt C.exactly allDeps)
           [ attempt C.exactly allDirects,
             attempt C.untilNextMinor allDirects,
-            attempt C.untilNextMajor allDirects,
-            attempt (\_ -> C.anything) allDirects
+            attempt C.untilNextMajor allDirects
           ] of
           Solver solver ->
             solver

--- a/builder/src/Deps/Solver.hs
+++ b/builder/src/Deps/Solver.hs
@@ -191,22 +191,6 @@ addConstraint solved unsolved (name, newConstraint) =
                 then return unsolved
                 else return (Map.insert name mergedConstraint unsolved)
 
--- GET RELEVANT VERSIONS
-
-{- TODO: do we still need this?
-getRelevantVersions :: Pkg.Name -> C.Constraint -> Solver (V.Version, [V.Version])
-getRelevantVersions name constraint =
-  Solver $ \state@(State _ _) ok back err -> do
-    versionsResult <- Package.getVersions name
-    case versionsResult of
-      Right (newest, previous) ->
-        case filter (C.satisfies constraint) (newest : previous) of
-          [] -> back state
-          v : vs -> ok state (v, vs) back
-      Left gitErr ->
-        err $ Exit.SolverBadGitOperationUnversionedPkg name gitErr
-        -}
-
 -- GET CONSTRAINTS
 
 getConstraints :: Pkg.Name -> V.Version -> Solver Constraints

--- a/builder/src/Directories.hs
+++ b/builder/src/Directories.hs
@@ -14,7 +14,6 @@ module Directories
     PackageCache,
     getPackageCache,
     package,
-    basePackage,
     getReplCache,
     getGrenHome,
   )
@@ -119,10 +118,6 @@ getPackageCache =
 package :: PackageCache -> Pkg.Name -> V.Version -> FilePath
 package (PackageCache dir) name version =
   dir </> Pkg.toFilePath name </> V.toChars version
-
-basePackage :: PackageCache -> Pkg.Name -> FilePath
-basePackage (PackageCache dir) name =
-  dir </> Pkg.toFilePath name </> "repo.git"
 
 -- CACHE
 

--- a/builder/src/Git.hs
+++ b/builder/src/Git.hs
@@ -4,8 +4,6 @@ module Git
     --
     githubUrl,
     clone,
-    localClone,
-    update,
     tags,
     --
     hasLocalTag,
@@ -13,9 +11,11 @@ module Git
   )
 where
 
-import Data.ByteString.Char8 qualified as BS
 import Data.Either qualified as Either
 import Data.List qualified as List
+import Data.Maybe qualified as Maybe
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TE
 import Gren.Package qualified as Pkg
 import Gren.Version qualified as V
 import Parse.Primitives qualified as Parser
@@ -27,7 +27,7 @@ import System.Process qualified as Process
 data Error
   = MissingGit
   | FailedCommand (Maybe FilePath) [String] String
-  | NoVersions FilePath
+  | NoVersions
 
 --
 
@@ -53,43 +53,21 @@ githubUrl pkg =
 
 --
 
-clone :: GitUrl -> FilePath -> IO (Either Error ())
-clone (GitUrl (pkgName, gitUrl)) targetFolder = do
+clone :: GitUrl -> V.Version -> FilePath -> IO (Either Error ())
+clone (GitUrl (pkgName, gitUrl)) vsn targetFolder = do
   maybeExec <- checkInstalledGit
-  putStrFlush $ "Cloning " ++ pkgName ++ "... "
-  case maybeExec of
-    Nothing -> do
-      putStrLn "Error!"
-      return $ Left MissingGit
-    Just git -> do
-      let args = ["clone", "--bare", gitUrl, targetFolder]
-      (exitCode, _, stderr) <-
-        Process.readCreateProcessWithExitCode
-          (Process.proc git args)
-          ""
-      case exitCode of
-        Exit.ExitFailure _ -> do
-          putStrLn "Error!"
-          return $ Left $ FailedCommand Nothing ("git" : args) stderr
-        Exit.ExitSuccess -> do
-          putStrLn "Ok!"
-          return $ Right ()
-
-localClone :: FilePath -> V.Version -> FilePath -> IO (Either Error ())
-localClone gitUrl vsn targetFolder = do
-  maybeExec <- checkInstalledGit
+  putStrFlush $ "Cloning " ++ pkgName ++ " " ++ V.toChars vsn ++ "... "
   case maybeExec of
     Nothing ->
       return $ Left MissingGit
     Just git -> do
       let args =
             [ "clone",
-              gitUrl,
-              "--local",
-              "-b",
+              "--branch",
               V.toChars vsn,
               "--depth",
               "1",
+              gitUrl,
               targetFolder
             ]
       (exitCode, _, stderr) <-
@@ -100,62 +78,61 @@ localClone gitUrl vsn targetFolder = do
         Exit.ExitFailure _ -> do
           putStrLn "Error!"
           return $ Left $ FailedCommand Nothing ("git" : args) stderr
-        Exit.ExitSuccess ->
-          return $ Right ()
-
-update :: Pkg.Name -> FilePath -> IO (Either Error ())
-update pkg path = do
-  maybeExec <- checkInstalledGit
-  putStrFlush $ "Updating " ++ Pkg.toChars pkg ++ "... "
-  case maybeExec of
-    Nothing -> do
-      putStrLn "Error!"
-      return $ Left MissingGit
-    Just git -> do
-      let args = ["fetch", "-t"]
-      (exitCode, _, stderr) <-
-        Process.readCreateProcessWithExitCode
-          ( (Process.proc git args)
-              { Process.cwd = Just path
-              }
-          )
-          ""
-      case exitCode of
-        Exit.ExitFailure _ -> do
-          putStrLn "Error!"
-          return $ Left $ FailedCommand (Just path) ("git" : args) stderr
         Exit.ExitSuccess -> do
           putStrLn "Ok!"
           return $ Right ()
 
-tags :: FilePath -> IO (Either Error (V.Version, [V.Version]))
-tags path = do
+tags :: GitUrl -> IO (Either Error (V.Version, [V.Version]))
+tags (GitUrl (pkgName, gitUrl)) = do
   maybeExec <- checkInstalledGit
+  putStrFlush $ "Retrieving versions for " ++ pkgName ++ "... "
   case maybeExec of
     Nothing ->
       return $ Left MissingGit
     Just git -> do
-      let args = ["tag"]
+      let args =
+            [ "ls-remote",
+              "--tags",
+              gitUrl
+            ]
       (exitCode, stdout, stderr) <-
         Process.readCreateProcessWithExitCode
-          ( (Process.proc git args)
-              { Process.cwd = Just path
-              }
-          )
+          (Process.proc git args)
           ""
       case exitCode of
         Exit.ExitFailure _ -> do
-          return $ Left $ FailedCommand (Just path) ("git" : args) stderr
+          putStrLn "Error!"
+          return $ Left $ FailedCommand Nothing ("git" : args) stderr
         Exit.ExitSuccess ->
           let tagList =
-                map BS.pack $ lines stdout
+                map (TE.encodeUtf8) $
+                  map (Text.replace (Text.pack "refs/tags/") Text.empty) $
+                    map (Text.pack) $
+                      map (Maybe.fromMaybe "" . listGet 1) $
+                        map words $
+                          lines stdout
 
-              -- Ignore tags that aren't semantic versions
               versions =
-                reverse $ List.sort $ Either.rights $ map (Parser.fromByteString V.parser (,)) tagList
-           in case versions of
-                [] -> return $ Left $ NoVersions path
-                v : vs -> return $ Right (v, vs)
+                reverse $
+                  List.sort $
+                    Either.rights $ -- Ignore tags that aren't semantic versions
+                      map (Parser.fromByteString V.parser (,)) tagList
+           in do
+                putStrLn "Ok!"
+                return $ case versions of
+                  [] -> Left NoVersions
+                  v : vs -> Right (v, vs)
+
+listGet :: Int -> [a] -> Maybe a
+listGet idx ls =
+  case ls of
+    [] -> Nothing
+    first : rest ->
+      if idx == 0
+        then Just first
+        else listGet (idx - 1) rest
+
+--
 
 hasLocalTag :: V.Version -> IO (Either Error ())
 hasLocalTag vsn = do

--- a/builder/src/Gren/Details.hs
+++ b/builder/src/Gren/Details.hs
@@ -187,7 +187,8 @@ verifyPkg :: Env -> File.Time -> Outline.PkgOutline -> Task Details
 verifyPkg env time (Outline.PkgOutline pkg _ _ _ exposed direct testDirect gren) =
   if Con.goodGren gren
     then do
-      solution <- verifyConstraints env =<< union noDups direct testDirect
+      stated <- union noDups direct testDirect
+      solution <- verifyConstraints env (Map.map (Con.exactly . Con.lowerBound) stated)
       let exposedList = Outline.flattenExposed exposed
       let exactDeps = Map.map (\(Solver.Details v _) -> v) solution -- for pkg docs in reactor
       verifyDependencies env time (ValidPkg pkg exposedList exactDeps) solution direct

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -85,6 +85,7 @@ data Init
   | InitNoOfflineSolution [Pkg.Name]
   | InitSolverProblem Solver
   | InitAlreadyExists
+  | InitNoCompatibleDependencies (Maybe Git.Error)
 
 initToReport :: Init -> Help.Report
 initToReport exit =
@@ -137,6 +138,20 @@ initToReport exit =
               "next?"
             ]
         ]
+    InitNoCompatibleDependencies Nothing ->
+      Help.report
+        "NO COMPATIBLE DEPENDENCIES"
+        Nothing
+        "I failed to find versions of the core packages which are compatible with your current\
+        \ Gren compiler. "
+        [ D.reflow "Maybe you need to update the compiler?"
+        ]
+    InitNoCompatibleDependencies (Just gitError) ->
+      toGitErrorReport
+        "FAILED TO LOAD DEPENDENCIES"
+        gitError
+        "I tried to find the latest compatible versions of some core packages, but failed\
+        \ due to a problem with Git. I use Git to download external dependencies from Github."
 
 -- DIFF
 

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -1888,9 +1888,9 @@ toGitErrorReport title err context =
             [ D.reflow "But it returned the following error message:",
               D.indent 4 $ D.reflow errorMsg
             ]
-        Git.NoVersions _ ->
+        Git.NoVersions ->
           toGitReport
-            (context ++ ", no valid semantic version tags in this repo.")
+            (context ++ ", no semver compatible tags in this repo.")
             [ D.reflow
                 "Gren packages are just git repositories with tags following the \
                 \ semantic versioning scheme. However, it seems that this particular repo \

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -863,6 +863,7 @@ data Install
   | InstallNoOnlinePkgSolution Pkg.Name
   | InstallNoOfflinePkgSolution Pkg.Name
   | InstallHadSolverTrouble Solver
+  | InstallNoCompatiblePkg Pkg.Name
   | InstallUnknownPackageOnline Pkg.Name [Pkg.Name]
   | InstallUnknownPackageOffline Pkg.Name [Pkg.Name]
   | InstallBadDetails Details
@@ -1060,6 +1061,18 @@ installToReport exit =
         ]
     InstallHadSolverTrouble solver ->
       toSolverReport solver
+    InstallNoCompatiblePkg pkg ->
+      Help.report
+        "CANNOT FIND COMPATIBLE VERSION"
+        (Just "gren.json")
+        ( "I cannot find a version of "
+            ++ Pkg.toChars pkg
+            ++ " that is compatible with your current Gren compiler."
+        )
+        [ D.reflow $
+            "You'll have to wait for the package to release a version with support for your\
+            \ current Gren compiler, or upgrade."
+        ]
     InstallUnknownPackageOnline pkg suggestions ->
       Help.docReport
         "UNKNOWN PACKAGE"

--- a/compiler/src/Gren/Constraint.hs
+++ b/compiler/src/Gren/Constraint.hs
@@ -5,6 +5,8 @@ module Gren.Constraint
   ( Constraint,
     exactly,
     anything,
+    lowerBound,
+    upperBound,
     toChars,
     satisfies,
     check,
@@ -49,6 +51,16 @@ exactly version =
 anything :: Constraint
 anything =
   Range V.one LessOrEqual LessOrEqual V.max
+
+-- EXTRACT VERSION
+
+lowerBound :: Constraint -> V.Version
+lowerBound (Range lower _ _ _) =
+  lower
+
+upperBound :: Constraint -> V.Version
+upperBound (Range _ _ _ upper) =
+  upper
 
 -- TO CHARS
 

--- a/compiler/src/Gren/Constraint.hs
+++ b/compiler/src/Gren/Constraint.hs
@@ -4,7 +4,6 @@
 module Gren.Constraint
   ( Constraint,
     exactly,
-    anything,
     lowerBound,
     upperBound,
     toChars,
@@ -47,10 +46,6 @@ data Op
 exactly :: V.Version -> Constraint
 exactly version =
   Range version LessOrEqual LessOrEqual version
-
-anything :: Constraint
-anything =
-  Range V.one LessOrEqual LessOrEqual V.max
 
 -- EXTRACT VERSION
 

--- a/gren.cabal
+++ b/gren.cabal
@@ -38,9 +38,9 @@ Flag dev {
 
 Common gren-common
     if flag(dev)
-        ghc-options: -O0 -Wall -Werror
+        ghc-options: -O0 -Wall
     else
-        ghc-options: -O2 -Wall -threaded "-with-rtsopts=-N"
+        ghc-options: -O2 -Wall -Werror -threaded "-with-rtsopts=-N"
 
     default-language: GHC2021
 

--- a/gren.cabal
+++ b/gren.cabal
@@ -1,7 +1,7 @@
 Cabal-version: 3.6
 
 Name: gren
-Version: 0.1.0
+Version: 0.2.0
 
 Synopsis:
     The `gren` command line interface.

--- a/gren.cabal
+++ b/gren.cabal
@@ -1,7 +1,7 @@
 Cabal-version: 3.6
 
 Name: gren
-Version: 0.2.0
+Version: 0.1.0
 
 Synopsis:
     The `gren` command line interface.

--- a/gren.cabal
+++ b/gren.cabal
@@ -50,9 +50,6 @@ Common gren-common
         terminal/impl
         terminal/src
 
-    other-extensions:
-        TemplateHaskell
-
     other-modules:
         Bump
         Diff
@@ -211,7 +208,8 @@ Common gren-common
         scientific,
         time >= 1.9.1,
         utf8-string,
-        vector
+        vector,
+        text >= 2 && < 3
 
 Executable gren
     Import:

--- a/terminal/src/Bump.hs
+++ b/terminal/src/Bump.hs
@@ -59,10 +59,10 @@ getEnv =
 -- BUMP
 
 bump :: Env -> Task.Task Exit.Bump ()
-bump env@(Env root cache outline@(Outline.PkgOutline pkg _ _ vsn _ _ _ _)) =
+bump env@(Env root _ outline@(Outline.PkgOutline pkg _ _ vsn _ _ _ _)) =
   Task.eio id $
     do
-      versionResult <- Dirs.withRegistryLock cache $ Package.getVersions cache pkg
+      versionResult <- Package.getVersions pkg
       case versionResult of
         Right knownVersions ->
           let bumpableVersions =

--- a/terminal/src/Diff.hs
+++ b/terminal/src/Diff.hs
@@ -69,11 +69,11 @@ type Task a =
   Task.Task Exit.Diff a
 
 diff :: Env -> Args -> Task ()
-diff env@(Env _ cache) args =
+diff env@(Env _ _) args =
   case args of
     GlobalInquiry name v1 v2 ->
       do
-        versionResult <- Task.io $ Dirs.withRegistryLock cache $ Package.getVersions cache name
+        versionResult <- Task.io $ Package.getVersions name
         case versionResult of
           Right vsns ->
             do
@@ -116,7 +116,7 @@ getLatestDocs (Env _ cache) name (latest, _) =
 -- READ OUTLINE
 
 readOutline :: Env -> Task (Pkg.Name, (V.Version, [V.Version]))
-readOutline (Env maybeRoot cache) =
+readOutline (Env maybeRoot _) =
   case maybeRoot of
     Nothing ->
       Task.throw Exit.DiffNoOutline
@@ -132,7 +132,7 @@ readOutline (Env maybeRoot cache) =
                 Task.throw Exit.DiffApplication
               Outline.Pkg (Outline.PkgOutline pkg _ _ _ _ _ _ _) ->
                 do
-                  versionResult <- Task.io $ Dirs.withRegistryLock cache $ Package.getVersions cache pkg
+                  versionResult <- Task.io $ Package.getVersions pkg
                   case versionResult of
                     Right vsns ->
                       return (pkg, vsns)

--- a/terminal/src/Init.hs
+++ b/terminal/src/Init.hs
@@ -6,10 +6,12 @@ module Init
   )
 where
 
+import Data.Either qualified as Either
 import Data.Map qualified as Map
 import Data.NonEmptyList qualified as NE
 import Deps.Package qualified as DPkg
 import Deps.Solver qualified as Solver
+import Directories qualified as Dirs
 import Gren.Constraint qualified as Con
 import Gren.Licenses qualified as Licenses
 import Gren.Outline qualified as Outline
@@ -73,16 +75,17 @@ init flags =
           if _isPackage flags
             then pkgDefaultDeps
             else appDefaultDeps
-    deps <- mapM (DPkg.getLatestCompatibleVersion cache) initialDeps
     (Solver.Env cache) <- Solver.initEnv
+    depsM <- mapM (compatibleDependencies cache) initialDeps
+    let deps = Map.fromList $ Either.rights depsM
     result <- Solver.verify cache deps
     case result of
       Solver.Err exit ->
         return (Left (Exit.InitSolverProblem exit))
       Solver.NoSolution ->
-        return (Left (Exit.InitNoSolution (Map.keys deps)))
+        return (Left (Exit.InitNoSolution initialDeps))
       Solver.NoOfflineSolution ->
-        return (Left (Exit.InitNoOfflineSolution (Map.keys deps)))
+        return (Left (Exit.InitNoOfflineSolution initialDeps))
       Solver.Ok details ->
         let outline =
               if _isPackage flags
@@ -93,6 +96,15 @@ init flags =
               Outline.write "." outline
               putStrLn "Okay, I created it."
               return (Right ())
+
+compatibleDependencies :: Dirs.PackageCache -> Pkg.Name -> IO (Either () (Pkg.Name, Con.Constraint))
+compatibleDependencies cache pkgName = do
+  possibleVersion <- DPkg.getLatestCompatibleVersion cache pkgName
+  case possibleVersion of
+    Left _ ->
+      return $ Left ()
+    Right vsn ->
+      return $ Right (pkgName, Con.untilNextMajor vsn)
 
 pkgOutline :: Map.Map Pkg.Name Con.Constraint -> Outline.Outline
 pkgOutline deps =
@@ -110,8 +122,9 @@ pkgOutline deps =
 appOutlineFromSolverDetails :: (Map.Map Pkg.Name Solver.Details) -> Outline.Outline
 appOutlineFromSolverDetails details =
   let solution = Map.map (\(Solver.Details vsn _) -> vsn) details
-      directs = Map.intersection solution appDefaultDeps
-      indirects = Map.difference solution appDefaultDeps
+      defaultDeps = Map.fromList $ map (\dep -> (dep, Con.anything)) appDefaultDeps
+      directs = Map.intersection solution defaultDeps
+      indirects = Map.difference solution defaultDeps
    in Outline.App $
         Outline.AppOutline
           V.compiler

--- a/terminal/src/Init.hs
+++ b/terminal/src/Init.hs
@@ -117,7 +117,7 @@ pkgOutline deps =
 appOutlineFromSolverDetails :: (Map.Map Pkg.Name Solver.Details) -> Outline.Outline
 appOutlineFromSolverDetails details =
   let solution = Map.map (\(Solver.Details vsn _) -> vsn) details
-      defaultDeps = Map.fromList $ map (\dep -> (dep, Con.anything)) appDefaultDeps
+      defaultDeps = Map.fromList $ map (\dep -> (dep, Con.exactly V.one)) appDefaultDeps
       directs = Map.intersection solution defaultDeps
       indirects = Map.difference solution defaultDeps
    in Outline.App $

--- a/terminal/src/Init.hs
+++ b/terminal/src/Init.hs
@@ -79,8 +79,10 @@ init flags =
       Dirs.withRegistryLock cache $
         DPkg.latestCompatibleVersionForPackages cache initialDeps
     case potentialDeps of
-      Left () ->
-        return $ Left $ Exit.InitNoSolution initialDeps
+      Left DPkg.NoCompatiblePackage ->
+        return $ Left $ Exit.InitNoCompatibleDependencies Nothing
+      Left (DPkg.GitError gitError) ->
+        return $ Left $ Exit.InitNoCompatibleDependencies $ Just gitError
       Right deps -> do
         result <- Solver.verify cache deps
         case result of

--- a/terminal/src/Install.hs
+++ b/terminal/src/Install.hs
@@ -10,6 +10,7 @@ import BackgroundWriter qualified as BW
 import Data.Map ((!))
 import Data.Map qualified as Map
 import Data.Map.Merge.Strict qualified as Map
+import Deps.Package qualified as DPkg
 import Deps.Solver qualified as Solver
 import Directories qualified as Dirs
 import Gren.Constraint qualified as C
@@ -208,18 +209,22 @@ makeAppPlan (Solver.Env cache) pkg outline@(Outline.AppOutline _ _ direct indire
                         { Outline._app_deps_direct = Map.insert pkg vsn direct,
                           Outline._app_test_indirect = Map.delete pkg testIndirect
                         }
-              Nothing ->
-                do
-                  result <- Task.io $ Solver.addToApp cache pkg outline
-                  case result of
-                    Solver.Ok (Solver.AppSolution old new app) ->
-                      return (Changes (detectChanges old new) (Outline.App app))
-                    Solver.NoSolution ->
-                      Task.throw (Exit.InstallNoOnlineAppSolution pkg)
-                    Solver.NoOfflineSolution ->
-                      Task.throw (Exit.InstallNoOfflineAppSolution pkg)
-                    Solver.Err exit ->
-                      Task.throw (Exit.InstallHadSolverTrouble exit)
+              Nothing -> do
+                compatibleVersionResult <- Task.io $ DPkg.getLatestCompatibleVersion cache pkg
+                case compatibleVersionResult of
+                  Left () ->
+                    Task.throw $ Exit.InstallNoCompatiblePkg pkg
+                  Right compatibleVersion -> do
+                    result <- Task.io $ Solver.addToApp cache pkg compatibleVersion outline
+                    case result of
+                      Solver.Ok (Solver.AppSolution old new app) ->
+                        return (Changes (detectChanges old new) (Outline.App app))
+                      Solver.NoSolution ->
+                        Task.throw (Exit.InstallNoOnlineAppSolution pkg)
+                      Solver.NoOfflineSolution ->
+                        Task.throw (Exit.InstallNoOfflineAppSolution pkg)
+                      Solver.Err exit ->
+                        Task.throw (Exit.InstallHadSolverTrouble exit)
 
 -- MAKE PACKAGE PLAN
 
@@ -239,30 +244,35 @@ makePkgPlan (Solver.Env cache) pkg outline@(Outline.PkgOutline _ _ _ _ _ deps te
                 }
       Nothing ->
         do
-          let old = Map.union deps test
-          let cons = Map.insert pkg C.anything old
-          result <- Task.io $ Solver.verify cache cons
-          case result of
-            Solver.Ok solution ->
-              let (Solver.Details vsn _) = solution ! pkg
+          compatibleVersionResult <- Task.io $ DPkg.getLatestCompatibleVersion cache pkg
+          case compatibleVersionResult of
+            Left () ->
+              Task.throw $ Exit.InstallNoCompatiblePkg pkg
+            Right compatibleVersion -> do
+              let old = Map.union deps test
+              let cons = Map.insert pkg (C.untilNextMajor compatibleVersion) old
+              result <- Task.io $ Solver.verify cache cons
+              case result of
+                Solver.Ok solution ->
+                  let (Solver.Details vsn _) = solution ! pkg
 
-                  con = C.untilNextMajor vsn
-                  new = Map.insert pkg con old
-                  changes = detectChanges old new
-                  news = Map.mapMaybe keepNew changes
-               in return $
-                    Changes changes $
-                      Outline.Pkg $
-                        outline
-                          { Outline._pkg_deps = addNews (Just pkg) news deps,
-                            Outline._pkg_test_deps = addNews Nothing news test
-                          }
-            Solver.NoSolution ->
-              Task.throw $ Exit.InstallNoOnlinePkgSolution pkg
-            Solver.NoOfflineSolution ->
-              Task.throw $ Exit.InstallNoOfflinePkgSolution pkg
-            Solver.Err exit ->
-              Task.throw $ Exit.InstallHadSolverTrouble exit
+                      con = C.untilNextMajor vsn
+                      new = Map.insert pkg con old
+                      changes = detectChanges old new
+                      news = Map.mapMaybe keepNew changes
+                   in return $
+                        Changes changes $
+                          Outline.Pkg $
+                            outline
+                              { Outline._pkg_deps = addNews (Just pkg) news deps,
+                                Outline._pkg_test_deps = addNews Nothing news test
+                              }
+                Solver.NoSolution ->
+                  Task.throw $ Exit.InstallNoOnlinePkgSolution pkg
+                Solver.NoOfflineSolution ->
+                  Task.throw $ Exit.InstallNoOfflinePkgSolution pkg
+                Solver.Err exit ->
+                  Task.throw $ Exit.InstallHadSolverTrouble exit
 
 addNews :: Maybe Pkg.Name -> Map.Map Pkg.Name C.Constraint -> Map.Map Pkg.Name C.Constraint -> Map.Map Pkg.Name C.Constraint
 addNews pkg new old =

--- a/terminal/src/Install.hs
+++ b/terminal/src/Install.hs
@@ -210,7 +210,10 @@ makeAppPlan (Solver.Env cache) pkg outline@(Outline.AppOutline _ _ direct indire
                           Outline._app_test_indirect = Map.delete pkg testIndirect
                         }
               Nothing -> do
-                compatibleVersionResult <- Task.io $ DPkg.getLatestCompatibleVersion cache pkg
+                compatibleVersionResult <-
+                  Task.io $
+                    Dirs.withRegistryLock cache $
+                      DPkg.getLatestCompatibleVersion cache pkg
                 case compatibleVersionResult of
                   Left () ->
                     Task.throw $ Exit.InstallNoCompatiblePkg pkg
@@ -244,7 +247,10 @@ makePkgPlan (Solver.Env cache) pkg outline@(Outline.PkgOutline _ _ _ _ _ deps te
                 }
       Nothing ->
         do
-          compatibleVersionResult <- Task.io $ DPkg.getLatestCompatibleVersion cache pkg
+          compatibleVersionResult <-
+            Task.io $
+              Dirs.withRegistryLock cache $
+                DPkg.getLatestCompatibleVersion cache pkg
           case compatibleVersionResult of
             Left () ->
               Task.throw $ Exit.InstallNoCompatiblePkg pkg

--- a/terminal/src/Install.hs
+++ b/terminal/src/Install.hs
@@ -213,7 +213,7 @@ makeAppPlan (Solver.Env cache) pkg outline@(Outline.AppOutline _ _ direct indire
                 compatibleVersionResult <-
                   Task.io $
                     Dirs.withRegistryLock cache $
-                      DPkg.getLatestCompatibleVersion cache pkg
+                      DPkg.latestCompatibleVersion cache pkg
                 case compatibleVersionResult of
                   Left () ->
                     Task.throw $ Exit.InstallNoCompatiblePkg pkg
@@ -250,7 +250,7 @@ makePkgPlan (Solver.Env cache) pkg outline@(Outline.PkgOutline _ _ _ _ _ deps te
           compatibleVersionResult <-
             Task.io $
               Dirs.withRegistryLock cache $
-                DPkg.getLatestCompatibleVersion cache pkg
+                DPkg.latestCompatibleVersion cache pkg
           case compatibleVersionResult of
             Left () ->
               Task.throw $ Exit.InstallNoCompatiblePkg pkg

--- a/terminal/src/Publish.hs
+++ b/terminal/src/Publish.hs
@@ -60,13 +60,13 @@ getEnv =
 -- PUBLISH
 
 publish :: Env -> Task.Task Exit.Publish ()
-publish env@(Env root cache outline) =
+publish env@(Env root _ outline) =
   case outline of
     Outline.App _ ->
       Task.throw Exit.PublishApplication
     Outline.Pkg (Outline.PkgOutline pkg summary _ vsn exposed _ _ _) ->
       do
-        knownVersionsResult <- Task.io $ Dirs.withRegistryLock cache $ Package.getVersions cache pkg
+        knownVersionsResult <- Task.io $ Package.getVersions pkg
         let knownVersionsMaybe = Either.either (const Nothing) Just knownVersionsResult
         reportPublishStart pkg vsn knownVersionsMaybe
 

--- a/terminal/src/Repl.hs
+++ b/terminal/src/Repl.hs
@@ -510,7 +510,7 @@ getRoot =
             Dirs.withRegistryLock packageCache $
               DPkg.latestCompatibleVersionForPackages packageCache defaultDeps
           case potentialDeps of
-            Left () ->
+            Left _ ->
               error "Failed to find compatible dependencies for this Gren version."
             Right compatibleDeps -> do
               Outline.write root $

--- a/terminal/src/Repl.hs
+++ b/terminal/src/Repl.hs
@@ -33,6 +33,7 @@ import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Maybe qualified as Maybe
 import Data.Name qualified as N
+import Deps.Package qualified as DPkg
 import Directories qualified as Dirs
 import Generate qualified
 import Gren.Constraint qualified as C
@@ -504,27 +505,33 @@ getRoot =
           cache <- Dirs.getReplCache
           let root = cache </> "tmp"
           Dir.createDirectoryIfMissing True (root </> "src")
-          Outline.write root $
-            Outline.Pkg $
-              Outline.PkgOutline
-                Pkg.dummyName
-                Outline.defaultSummary
-                Licenses.bsd3
-                V.one
-                (Outline.ExposedList [])
-                defaultDeps
-                Map.empty
-                C.defaultGren
+          packageCache <- Dirs.getPackageCache
+          potentialDeps <-
+            Dirs.withRegistryLock packageCache $
+              DPkg.latestCompatibleVersionForPackages packageCache defaultDeps
+          case potentialDeps of
+            Left () ->
+              error "Failed to find compatible dependencies for this Gren version."
+            Right compatibleDeps -> do
+              Outline.write root $
+                Outline.Pkg $
+                  Outline.PkgOutline
+                    Pkg.dummyName
+                    Outline.defaultSummary
+                    Licenses.bsd3
+                    V.one
+                    (Outline.ExposedList [])
+                    compatibleDeps
+                    Map.empty
+                    C.defaultGren
 
-          return root
+              return root
 
-defaultDeps :: Map.Map Pkg.Name C.Constraint
+defaultDeps :: [Pkg.Name]
 defaultDeps =
-  Map.fromList
-    [ (Pkg.core, C.anything),
-      (Pkg.json, C.anything),
-      (Pkg.html, C.anything)
-    ]
+  [ Pkg.core,
+    Pkg.browser
+  ]
 
 -- GET INTERPRETER
 


### PR DESCRIPTION
Compiling example-projects with cold cache:

without this pr: 45 seconds
with this pr: 13 seconds

## TODO

- [x] `init` must retrieve the latest versions on its own
- [x] `install` must retrieve the latest version on its own
- [x] `repl` must retrieve the latest version on its own
- [x] when resolving the dependencies of a package project, convert all top-level constraints to exact constraints based on the lower bound
- [x] find and fix all problems when multiple transient dependencies are involved (i'd be surprised if there aren't any)