### PR TITLE
Fix ghc warnings

### DIFF
--- a/compiler/src/Gren/Docs.hs
+++ b/compiler/src/Gren/Docs.hs
@@ -289,7 +289,7 @@ chompOverview names =
     isDocs <- chompUntilDocs
     if isDocs
       then do
-        Space.chomp E.Space
+        _ <- Space.chomp E.Space
         chompOverview =<< chompDocs names
       else return names
 
@@ -305,14 +305,14 @@ chompDocs names =
             chompOperator
           ]
 
-    Space.chomp E.Space
+    _ <- Space.chomp E.Space
 
     P.oneOfWithFallback
       [ do
           pos <- P.getPosition
           Space.checkIndent pos E.Comma
           word1 0x2C {-,-} E.Comma
-          Space.chomp E.Space
+          _ <- Space.chomp E.Space
           chompDocs (name : names)
       ]
       (name : names)

--- a/compiler/src/Gren/Kernel.hs
+++ b/compiler/src/Gren/Kernel.hs
@@ -84,7 +84,7 @@ parser :: Pkg.Name -> Foreigns -> Parser () Content
 parser pkg foreigns =
   do
     word2 0x2F 0x2A {-/*-} toError
-    Space.chomp ignoreError
+    _ <- Space.chomp ignoreError
     Space.checkFreshLine toError
     imports <- specialize ignoreError (Module.chompImports [])
     word2 0x2A 0x2F toError -- /

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -65,7 +65,7 @@ parenthesizedExpr :: A.Position -> Parser E.Expr Src.Expr
 parenthesizedExpr start@(A.Position row col) =
   inContext E.Parenthesized (word1 0x28 {-(-} E.Start) $
     do
-      Space.chompAndCheckIndent E.ParenthesizedSpace E.ParenthesizedIndentOpen
+      _ <- Space.chompAndCheckIndent E.ParenthesizedSpace E.ParenthesizedIndentOpen
       oneOf
         E.ParenthesizedOpen
         [ do
@@ -82,7 +82,7 @@ parenthesizedExpr start@(A.Position row col) =
                         specialize E.ParenthesizedExpr $
                           do
                             negatedExpr@(A.At (A.Region _ end) _) <- term
-                            Space.chomp E.Space
+                            _ <- Space.chomp E.Space
                             let exprStart = A.Position row (col + 2)
                             let expr = A.at exprStart end (Src.Negate negatedExpr)
                             chompExprEnd exprStart (State [] expr [] end)
@@ -131,7 +131,7 @@ array :: A.Position -> Parser E.Expr Src.Expr
 array start =
   inContext E.Array (word1 0x5B {-[-} E.Start) $
     do
-      Space.chompAndCheckIndent E.ArraySpace E.ArrayIndentOpen
+      _ <- Space.chompAndCheckIndent E.ArraySpace E.ArrayIndentOpen
       oneOf
         E.ArrayOpen
         [ do
@@ -149,7 +149,7 @@ chompArrayEnd start entries =
     E.ArrayEnd
     [ do
         word1 0x2C {-,-} E.ArrayEnd
-        Space.chompAndCheckIndent E.ArraySpace E.ArrayIndentExpr
+        _ <- Space.chompAndCheckIndent E.ArraySpace E.ArrayIndentExpr
         (entry, end) <- specialize E.ArrayExpr expression
         Space.checkIndent end E.ArrayIndentEnd
         chompArrayEnd start (entry : entries),
@@ -164,7 +164,7 @@ record :: A.Position -> Parser E.Expr Src.Expr
 record start =
   inContext E.Record (word1 0x7B {- { -} E.Start) $
     do
-      Space.chompAndCheckIndent E.RecordSpace E.RecordIndentOpen
+      _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentOpen
       oneOf
         E.RecordOpen
         [ do
@@ -172,18 +172,18 @@ record start =
             addEnd start (Src.Record []),
           do
             expr <- specialize E.RecordUpdateExpr term
-            Space.chompAndCheckIndent E.RecordSpace E.RecordIndentEquals
+            _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentEquals
             oneOf
               E.RecordEquals
               [ do
                   word1 0x7C {- vertical bar -} E.RecordPipe
-                  Space.chompAndCheckIndent E.RecordSpace E.RecordIndentField
+                  _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentField
                   firstField <- chompField
                   fields <- chompFields [firstField]
                   addEnd start (Src.Update expr fields),
                 do
                   word1 0x3D {-=-} E.RecordEquals
-                  Space.chompAndCheckIndent E.RecordSpace E.RecordIndentExpr
+                  _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentExpr
                   (value, end) <- specialize E.RecordExpr expression
                   Space.checkIndent end E.RecordIndentEnd
                   case expr of
@@ -204,7 +204,7 @@ chompFields fields =
     E.RecordEnd
     [ do
         word1 0x2C {-,-} E.RecordEnd
-        Space.chompAndCheckIndent E.RecordSpace E.RecordIndentField
+        _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentField
         f <- chompField
         chompFields (f : fields),
       do
@@ -216,9 +216,9 @@ chompField :: Parser E.Record Field
 chompField =
   do
     key <- addLocation (Var.lower E.RecordField)
-    Space.chompAndCheckIndent E.RecordSpace E.RecordIndentEquals
+    _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentEquals
     word1 0x3D {-=-} E.RecordEquals
-    Space.chompAndCheckIndent E.RecordSpace E.RecordIndentExpr
+    _ <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentExpr
     (value, end) <- specialize E.RecordExpr expression
     Space.checkIndent end E.RecordIndentEnd
     return (key, value)
@@ -238,7 +238,7 @@ expression =
         do
           expr <- possiblyNegativeTerm start
           end <- getPosition
-          Space.chomp E.Space
+          _ <- Space.chomp E.Space
           chompExprEnd start (State [] expr [] end)
       ]
 
@@ -257,20 +257,20 @@ chompExprEnd start (State ops expr args end) =
         Space.checkIndent end E.Start
         arg <- term
         newEnd <- getPosition
-        Space.chomp E.Space
+        _ <- Space.chomp E.Space
         chompExprEnd start (State ops expr (arg : args) newEnd),
       -- operator
       do
         Space.checkIndent end E.Start
         op@(A.At (A.Region opStart opEnd) opName) <- addLocation (Symbol.operator E.Start E.OperatorReserved)
-        Space.chompAndCheckIndent E.Space (E.IndentOperatorRight opName)
+        _ <- Space.chompAndCheckIndent E.Space (E.IndentOperatorRight opName)
         newStart <- getPosition
         if "-" == opName && end /= opStart && opEnd == newStart
           then -- negative terms
           do
             negatedExpr <- term
             newEnd <- getPosition
-            Space.chomp E.Space
+            _ <- Space.chomp E.Space
             let arg = A.at opStart newEnd (Src.Negate negatedExpr)
             chompExprEnd start (State ops expr (arg : args) newEnd)
           else
@@ -281,7 +281,7 @@ chompExprEnd start (State ops expr args end) =
                     do
                       newExpr <- possiblyNegativeTerm newStart
                       newEnd <- getPosition
-                      Space.chomp E.Space
+                      _ <- Space.chomp E.Space
                       let newOps = (toCall expr args, op) : ops
                       chompExprEnd start (State newOps newExpr [] newEnd),
                     -- final term
@@ -340,15 +340,15 @@ if_ start =
 chompIfEnd :: A.Position -> [(Src.Expr, Src.Expr)] -> Space.Parser E.If Src.Expr
 chompIfEnd start branches =
   do
-    Space.chompAndCheckIndent E.IfSpace E.IfIndentCondition
+    _ <- Space.chompAndCheckIndent E.IfSpace E.IfIndentCondition
     (condition, condEnd) <- specialize E.IfCondition expression
     Space.checkIndent condEnd E.IfIndentThen
     Keyword.then_ E.IfThen
-    Space.chompAndCheckIndent E.IfSpace E.IfIndentThenBranch
+    _ <- Space.chompAndCheckIndent E.IfSpace E.IfIndentThenBranch
     (thenBranch, thenEnd) <- specialize E.IfThenBranch expression
     Space.checkIndent thenEnd E.IfIndentElse
     Keyword.else_ E.IfElse
-    Space.chompAndCheckIndent E.IfSpace E.IfIndentElseBranch
+    _ <- Space.chompAndCheckIndent E.IfSpace E.IfIndentElseBranch
     let newBranches = (condition, thenBranch) : branches
     oneOf
       E.IfElseBranchStart
@@ -367,11 +367,11 @@ function :: A.Position -> Space.Parser E.Expr Src.Expr
 function start =
   inContext E.Func (word1 0x5C {-\-} E.Start) $
     do
-      Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArg
+      _ <- Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArg
       arg <- specialize E.FuncArg Pattern.term
-      Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArrow
+      _ <- Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArrow
       revArgs <- chompArgs [arg]
-      Space.chompAndCheckIndent E.FuncSpace E.FuncIndentBody
+      _ <- Space.chompAndCheckIndent E.FuncSpace E.FuncIndentBody
       (body, end) <- specialize E.FuncBody expression
       let funcExpr = Src.Lambda (reverse revArgs) body
       return (A.at start end funcExpr, end)
@@ -382,7 +382,7 @@ chompArgs revArgs =
     E.FuncArrow
     [ do
         arg <- specialize E.FuncArg Pattern.term
-        Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArrow
+        _ <- Space.chompAndCheckIndent E.FuncSpace E.FuncIndentArrow
         chompArgs (arg : revArgs),
       do
         word2 0x2D 0x3E {-->-} E.FuncArrow
@@ -395,11 +395,11 @@ case_ :: A.Position -> Space.Parser E.Expr Src.Expr
 case_ start =
   inContext E.Case (Keyword.case_ E.Start) $
     do
-      Space.chompAndCheckIndent E.CaseSpace E.CaseIndentExpr
+      _ <- Space.chompAndCheckIndent E.CaseSpace E.CaseIndentExpr
       (expr, exprEnd) <- specialize E.CaseExpr expression
       Space.checkIndent exprEnd E.CaseIndentOf
       Keyword.of_ E.CaseOf
-      Space.chompAndCheckIndent E.CaseSpace E.CaseIndentPattern
+      _ <- Space.chompAndCheckIndent E.CaseSpace E.CaseIndentPattern
       withIndent $
         do
           (firstBranch, firstEnd) <- chompBranch
@@ -415,7 +415,7 @@ chompBranch =
     (pattern, patternEnd) <- specialize E.CasePattern Pattern.expression
     Space.checkIndent patternEnd E.CaseIndentArrow
     word2 0x2D 0x3E {-->-} E.CaseArrow
-    Space.chompAndCheckIndent E.CaseSpace E.CaseIndentBranch
+    _ <- Space.chompAndCheckIndent E.CaseSpace E.CaseIndentBranch
     (branchExpr, end) <- specialize E.CaseBranch expression
     return ((pattern, branchExpr), end)
 
@@ -438,7 +438,7 @@ let_ start =
       (defs, defsEnd) <-
         withBacksetIndent 3 $
           do
-            Space.chompAndCheckIndent E.LetSpace E.LetIndentDef
+            _ <- Space.chompAndCheckIndent E.LetSpace E.LetIndentDef
             withIndent $
               do
                 (def, end) <- chompLetDef
@@ -446,7 +446,7 @@ let_ start =
 
       Space.checkIndent defsEnd E.LetIndentIn
       Keyword.in_ E.LetIn
-      Space.chompAndCheckIndent E.LetSpace E.LetIndentBody
+      _ <- Space.chompAndCheckIndent E.LetSpace E.LetIndentBody
       (body, end) <- specialize E.LetBody expression
       return
         ( A.at start end (Src.Let defs body),
@@ -481,16 +481,16 @@ definition =
     aname@(A.At (A.Region start _) name) <- addLocation (Var.lower E.LetDefName)
     specialize (E.LetDef name) $
       do
-        Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
+        _ <- Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
         oneOf
           E.DefEquals
           [ do
               word1 0x3A {-:-} E.DefEquals
-              Space.chompAndCheckIndent E.DefSpace E.DefIndentType
+              _ <- Space.chompAndCheckIndent E.DefSpace E.DefIndentType
               (tipe, _) <- specialize E.DefType Type.expression
               Space.checkAligned E.DefAlignment
               defName <- chompMatchingName name
-              Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
+              _ <- Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
               chompDefArgsAndBody start defName (Just tipe) [],
             chompDefArgsAndBody start aname Nothing []
           ]
@@ -501,11 +501,11 @@ chompDefArgsAndBody start name tipe revArgs =
     E.DefEquals
     [ do
         arg <- specialize E.DefArg Pattern.term
-        Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
+        _ <- Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
         chompDefArgsAndBody start name tipe (arg : revArgs),
       do
         word1 0x3D {-=-} E.DefEquals
-        Space.chompAndCheckIndent E.DefSpace E.DefIndentBody
+        _ <- Space.chompAndCheckIndent E.DefSpace E.DefIndentBody
         (body, end) <- specialize E.DefBody expression
         return
           ( A.at start end (Src.Define name (reverse revArgs) body tipe),
@@ -536,8 +536,8 @@ destructure =
     do
       start <- getPosition
       pattern <- specialize E.DestructPattern Pattern.term
-      Space.chompAndCheckIndent E.DestructSpace E.DestructIndentEquals
+      _ <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentEquals
       word1 0x3D {-=-} E.DestructEquals
-      Space.chompAndCheckIndent E.DestructSpace E.DestructIndentBody
+      _ <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentBody
       (expr, end) <- specialize E.DestructBody expression
       return (A.at start end (Src.Destruct pattern expr), end)

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -190,11 +190,11 @@ chompInfixes infixes =
 chompModuleDocCommentSpace :: Parser E.Module (Either A.Region Src.DocComment)
 chompModuleDocCommentSpace =
   do
-    (A.At region comments) <- addLocation (freshLine E.FreshLine)
+    (A.At region _comments) <- addLocation (freshLine E.FreshLine)
     oneOfWithFallback
       [ do
           docComment <- Space.docComment E.ImportStart E.ModuleSpace
-          Space.chomp E.ModuleSpace
+          _ <- Space.chomp E.ModuleSpace
           Space.checkFreshLine E.FreshLine
           return (Right docComment)
       ]
@@ -213,18 +213,18 @@ data Effects
 chompHeader :: Parser E.Module (Maybe Header)
 chompHeader =
   do
-    freshLine E.FreshLine
+    _ <- freshLine E.FreshLine
     start <- getPosition
     oneOfWithFallback
       [ -- module MyThing exposing (..)
         do
           Keyword.module_ E.ModuleProblem
           effectEnd <- getPosition
-          Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
           name <- addLocation (Var.moduleName E.ModuleName)
-          Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
           Keyword.exposing_ E.ModuleProblem
-          Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.ModuleProblem
           exports <- addLocation (specialize E.ModuleExposing exposing)
           comment <- chompModuleDocCommentSpace
           return $
@@ -233,14 +233,14 @@ chompHeader =
         -- port module MyThing exposing (..)
         do
           Keyword.port_ E.PortModuleProblem
-          Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
           Keyword.module_ E.PortModuleProblem
           effectEnd <- getPosition
-          Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
           name <- addLocation (Var.moduleName E.PortModuleName)
-          Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
           Keyword.exposing_ E.PortModuleProblem
-          Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.PortModuleProblem
           exports <- addLocation (specialize E.PortModuleExposing exposing)
           comment <- chompModuleDocCommentSpace
           return $
@@ -249,18 +249,18 @@ chompHeader =
         -- effect module MyThing where { command = MyCmd } exposing (..)
         do
           Keyword.effect_ E.Effect
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           Keyword.module_ E.Effect
           effectEnd <- getPosition
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           name <- addLocation (Var.moduleName E.ModuleName)
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           Keyword.where_ E.Effect
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           manager <- chompManager
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           Keyword.exposing_ E.Effect
-          Space.chompAndCheckIndent E.ModuleSpace E.Effect
+          _ <- Space.chompAndCheckIndent E.ModuleSpace E.Effect
           exports <- addLocation (specialize (const E.Effect) exposing)
           comment <- chompModuleDocCommentSpace
           return $
@@ -274,43 +274,43 @@ chompManager :: Parser E.Module Src.Manager
 chompManager =
   do
     word1 0x7B {- { -} E.Effect
-    spaces_em
+    _ <- spaces_em
     oneOf
       E.Effect
       [ do
           cmd <- chompCommand
-          spaces_em
+          _ <- spaces_em
           oneOf
             E.Effect
             [ do
                 word1 0x7D {-}-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 return (Src.Cmd cmd),
               do
                 word1 0x2C {-,-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 sub <- chompSubscription
-                spaces_em
+                _ <- spaces_em
                 word1 0x7D {-}-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 return (Src.Fx cmd sub)
             ],
         do
           sub <- chompSubscription
-          spaces_em
+          _ <- spaces_em
           oneOf
             E.Effect
             [ do
                 word1 0x7D {-}-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 return (Src.Sub sub),
               do
                 word1 0x2C {-,-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 cmd <- chompCommand
-                spaces_em
+                _ <- spaces_em
                 word1 0x7D {-}-} E.Effect
-                spaces_em
+                _ <- spaces_em
                 return (Src.Fx cmd sub)
             ]
       ]
@@ -319,18 +319,18 @@ chompCommand :: Parser E.Module (A.Located Name.Name)
 chompCommand =
   do
     Keyword.command_ E.Effect
-    spaces_em
+    _ <- spaces_em
     word1 0x3D {-=-} E.Effect
-    spaces_em
+    _ <- spaces_em
     addLocation (Var.upper E.Effect)
 
 chompSubscription :: Parser E.Module (A.Located Name.Name)
 chompSubscription =
   do
     Keyword.subscription_ E.Effect
-    spaces_em
+    _ <- spaces_em
     word1 0x3D {-=-} E.Effect
-    spaces_em
+    _ <- spaces_em
     addLocation (Var.upper E.Effect)
 
 spaces_em :: Parser E.Module [Src.Comment]
@@ -352,9 +352,9 @@ chompImport :: Parser E.Module Src.Import
 chompImport =
   do
     Keyword.import_ E.ImportStart
-    Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentName
+    _ <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentName
     name@(A.At (A.Region _ end) _) <- addLocation (Var.moduleName E.ImportName)
-    Space.chomp E.ModuleSpace
+    _ <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
       [ do
@@ -373,10 +373,10 @@ chompAs :: A.Located Name.Name -> Parser E.Module Src.Import
 chompAs name =
   do
     Keyword.as_ E.ImportAs
-    Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentAlias
+    _ <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentAlias
     alias <- Var.upper E.ImportAlias
     end <- getPosition
-    Space.chomp E.ModuleSpace
+    _ <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
       [ do
@@ -391,9 +391,9 @@ chompExposing :: A.Located Name.Name -> Maybe Name.Name -> Parser E.Module Src.I
 chompExposing name maybeAlias =
   do
     Keyword.exposing_ E.ImportExposing
-    Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentExposingArray
+    _ <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentExposingArray
     exposed <- specialize E.ImportExposingArray exposing
-    freshLine E.ImportEnd
+    _ <- freshLine E.ImportEnd
     return $ Src.Import name maybeAlias exposed
 
 -- LISTING
@@ -402,17 +402,17 @@ exposing :: Parser E.Exposing Src.Exposing
 exposing =
   do
     word1 0x28 {-(-} E.ExposingStart
-    Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentValue
+    _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentValue
     oneOf
       E.ExposingValue
       [ do
           word2 0x2E 0x2E {-..-} E.ExposingValue
-          Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
+          _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
           word1 0x29 {-)-} E.ExposingEnd
           return Src.Open,
         do
           exposed <- chompExposed
-          Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
+          _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
           exposingHelp [exposed]
       ]
 
@@ -422,9 +422,9 @@ exposingHelp revExposed =
     E.ExposingEnd
     [ do
         word1 0x2C {-,-} E.ExposingEnd
-        Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentValue
+        _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentValue
         exposed <- chompExposed
-        Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
+        _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
         exposingHelp (exposed : revExposed),
       do
         word1 0x29 {-)-} E.ExposingEnd
@@ -450,7 +450,7 @@ chompExposed =
         do
           name <- Var.upper E.ExposingValue
           end <- getPosition
-          Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
+          _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingIndentEnd
           Src.Upper (A.at start end name) <$> privacy
       ]
 
@@ -459,11 +459,11 @@ privacy =
   oneOfWithFallback
     [ do
         word1 0x28 {-(-} E.ExposingTypePrivacy
-        Space.chompAndCheckIndent E.ExposingSpace E.ExposingTypePrivacy
+        _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingTypePrivacy
         start <- getPosition
         word2 0x2E 0x2E {-..-} E.ExposingTypePrivacy
         end <- getPosition
-        Space.chompAndCheckIndent E.ExposingSpace E.ExposingTypePrivacy
+        _ <- Space.chompAndCheckIndent E.ExposingSpace E.ExposingTypePrivacy
         word1 0x29 {-)-} E.ExposingTypePrivacy
         return $ Src.Public (A.Region start end)
     ]

--- a/compiler/src/Parse/Pattern.hs
+++ b/compiler/src/Parse/Pattern.hs
@@ -101,7 +101,7 @@ parenthesized :: Parser E.Pattern Src.Pattern
 parenthesized =
   inContext E.PParenthesized (word1 0x28 {-(-} E.PStart) $
     do
-      Space.chompAndCheckIndent E.PParenthesizedSpace E.PParenthesizedIndentPattern
+      _ <- Space.chompAndCheckIndent E.PParenthesizedSpace E.PParenthesizedIndentPattern
       (pattern, end) <- P.specialize E.PParenthesizedPattern expression
       Space.checkIndent end E.PParenthesizedIndentEnd
       word1 0x29 {-)-} E.PParenthesizedEnd
@@ -113,7 +113,7 @@ record :: A.Position -> Parser E.Pattern Src.Pattern
 record start =
   inContext E.PRecord (word1 0x7B {- { -} E.PStart) $
     do
-      Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentOpen
+      _ <- Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentOpen
       oneOf
         E.PRecordOpen
         [ do
@@ -128,14 +128,14 @@ recordPatternHelp start revPatterns =
     fieldStart <- getPosition
     var <- Var.lower E.PRecordField
     varEnd <- getPosition
-    Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentEnd
+    _ <- Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentEnd
     oneOf
       E.PRecordEnd
       [ do
           word1 0x3D {-=-} E.PRecordEquals
-          Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentField
+          _ <- Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentField
           (pattern, fieldEnd) <- P.specialize E.PRecordExpr expression
-          Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentEnd
+          _ <- Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentEnd
           let namedPattern =
                 A.at fieldStart fieldEnd $
                   Src.RFPattern (A.at fieldStart varEnd var) pattern
@@ -155,7 +155,7 @@ recordContinuationHelp start revPatterns =
     E.PRecordEnd
     [ do
         word1 0x2C {-,-} E.PRecordEnd
-        Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentField
+        _ <- Space.chompAndCheckIndent E.PRecordSpace E.PRecordIndentField
         recordPatternHelp start revPatterns,
       do
         word1 0x7D {-}-} E.PRecordEnd
@@ -168,7 +168,7 @@ array :: A.Position -> Parser E.Pattern Src.Pattern
 array start =
   inContext E.PArray (word1 0x5B {-[-} E.PStart) $
     do
-      Space.chompAndCheckIndent E.PArraySpace E.PArrayIndentOpen
+      _ <- Space.chompAndCheckIndent E.PArraySpace E.PArrayIndentOpen
       oneOf
         E.PArrayOpen
         [ do
@@ -186,7 +186,7 @@ arrayHelp start patterns =
     E.PArrayEnd
     [ do
         word1 0x2C {-,-} E.PArrayEnd
-        Space.chompAndCheckIndent E.PArraySpace E.PArrayIndentExpr
+        _ <- Space.chompAndCheckIndent E.PArraySpace E.PArrayIndentExpr
         (pattern, end) <- P.specialize E.PArrayExpr expression
         Space.checkIndent end E.PArrayIndentEnd
         arrayHelp start (pattern : patterns),
@@ -209,11 +209,11 @@ exprHelp start (pattern, end) =
     [ do
         Space.checkIndent end E.PIndentStart
         Keyword.as_ E.PStart
-        Space.chompAndCheckIndent E.PSpace E.PIndentAlias
+        _ <- Space.chompAndCheckIndent E.PSpace E.PIndentAlias
         nameStart <- getPosition
         name <- Var.lower E.PAlias
         newEnd <- getPosition
-        Space.chomp E.PSpace
+        _ <- Space.chomp E.PSpace
         let alias = A.at nameStart newEnd name
         return
           ( A.at start newEnd (Src.PAlias pattern alias),
@@ -235,7 +235,7 @@ exprPart =
         exprTermHelp (A.Region start end) upper start [],
       do
         eterm@(A.At (A.Region _ end) _) <- term
-        Space.chomp E.PSpace
+        _ <- Space.chomp E.PSpace
         return (eterm, end)
     ]
 
@@ -243,7 +243,7 @@ exprTermHelp :: A.Region -> Var.Upper -> A.Position -> [Src.Pattern] -> Space.Pa
 exprTermHelp region upper start revArgs =
   do
     end <- getPosition
-    Space.chomp E.PSpace
+    _ <- Space.chomp E.PSpace
     oneOfWithFallback
       [ do
           Space.checkIndent end E.PIndentStart


### PR DESCRIPTION
There's an alarming amount of ghc warnings that clutter build (and CI) output.
I consider it important to strive for warning-free codebase, because even though the warnings are inconsequential, they make it difficult to spot other, potentially more important warnings.

An example of one warning that this fixes:
```
compiler/src/Parse/Type.hs:46:13: warning: [-Wunused-do-bind]
Warning:     A do-notation statement discarded a result of type ‘[Src.Comment]’
    Suppress this warning by saying
      ‘_ <- Space.chompAndCheckIndent
              E.TParenthesisSpace E.TParenthesisIndentOpen’
   |
46 |             Space.chompAndCheckIndent E.TParenthesisSpace E.TParenthesisIndentOpen
```