### PR TITLE
Add support for compiling NodeJS applications

### DIFF
--- a/builder/src/Gren/Platform.hs
+++ b/builder/src/Gren/Platform.hs
@@ -9,6 +9,7 @@ module Gren.Platform
   )
 where
 
+import Data.Binary (Binary, get, getWord8, put, putWord8)
 import Data.Utf8 qualified as Utf8
 import Json.Decode qualified as D
 import Json.Encode qualified as E
@@ -50,3 +51,21 @@ fromString value =
     "browser" -> Just Browser
     "node" -> Just Node
     _ -> Nothing
+
+-- BINARY
+
+instance Binary Platform where
+  put platform =
+    case platform of
+      Common -> putWord8 0
+      Browser -> putWord8 1
+      Node -> putWord8 2
+
+  get =
+    do
+      n <- getWord8
+      case n of
+        0 -> return Common
+        1 -> return Browser
+        2 -> return Node
+        _ -> fail "binary encoding of Platform was corrupted"

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -1962,12 +1962,13 @@ data Make
   | MakeBadDetails Details
   | MakeAppNeedsFileNames
   | MakePkgNeedsExposing
-  | MakeMultipleFilesIntoHtml
+  | MakeMultipleFiles
   | MakeNoMain
   | MakeNonMainFilesIntoJavaScript ModuleName.Raw [ModuleName.Raw]
   | MakeCannotBuild BuildProblem
   | MakeBadGenerate Generate
   | MakeHtmlOnlyForBrowserPlatform
+  | MakeExeOnlyForNodePlatform
 
 makeToReport :: Make -> Help.Report
 makeToReport make =
@@ -2032,11 +2033,11 @@ makeToReport make =
             "You can also entries to the \"exposed-modules\" list in your gren.json file, and\
             \ I will try to compile the relevant files."
         ]
-    MakeMultipleFilesIntoHtml ->
+    MakeMultipleFiles ->
       Help.report
         "TOO MANY FILES"
         Nothing
-        ( "When producing an HTML file, I can only handle one file."
+        ( "When producing an HTML file or executable, I can only handle one file."
         )
         [ D.fillSep
             [ "Switch",
@@ -2209,6 +2210,16 @@ makeToReport make =
         )
         [ D.reflow $
             "Try changing the `target` value in `gren.json` to `browser`.\
+            \ alternatively, pass a filename ending with `.js` to the compiler."
+        ]
+    MakeExeOnlyForNodePlatform ->
+      Help.report
+        "EXECUTABLES CAN ONLY BE CREATED FOR NODE PLATFORM"
+        Nothing
+        ( "When producing an executable, I require that the project platform is `node`."
+        )
+        [ D.reflow $
+            "Try changing the `target` value in `gren.json` to `node`.\
             \ alternatively, pass a filename ending with `.js` to the compiler."
         ]
 

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -1967,6 +1967,7 @@ data Make
   | MakeNonMainFilesIntoJavaScript ModuleName.Raw [ModuleName.Raw]
   | MakeCannotBuild BuildProblem
   | MakeBadGenerate Generate
+  | MakeHtmlOnlyForBrowserPlatform
 
 makeToReport :: Make -> Help.Report
 makeToReport make =
@@ -2200,6 +2201,16 @@ makeToReport make =
       toBuildProblemReport buildProblem
     MakeBadGenerate generateProblem ->
       toGenerateReport generateProblem
+    MakeHtmlOnlyForBrowserPlatform ->
+      Help.report
+        "HTML FILES CAN ONLY BE CREATED FOR BROWSER PLATFORM"
+        Nothing
+        ( "When producing a HTML file, I require that the project platform is `browser`."
+        )
+        [ D.reflow $
+            "Try changing the `target` value in `gren.json` to `browser`.\
+            \ alternatively, pass a filename ending with `.js` to the compiler."
+        ]
 
 -- BUILD PROBLEM
 

--- a/compiler/src/AST/Optimized.hs
+++ b/compiler/src/AST/Optimized.hs
@@ -117,7 +117,8 @@ data LocalGraph = LocalGraph
   }
 
 data Main
-  = Static
+  = StaticString
+  | StaticVDom
   | Dynamic
       { _message :: Can.Type,
         _decoder :: Expr
@@ -339,15 +340,17 @@ instance Binary LocalGraph where
 instance Binary Main where
   put main =
     case main of
-      Static -> putWord8 0
-      Dynamic a b -> putWord8 1 >> put a >> put b
+      StaticString -> putWord8 0
+      StaticVDom -> putWord8 1
+      Dynamic a b -> putWord8 2 >> put a >> put b
 
   get =
     do
       word <- getWord8
       case word of
-        0 -> return Static
-        1 -> liftM2 Dynamic get get
+        0 -> return StaticString
+        1 -> return StaticVDom
+        2 -> liftM2 Dynamic get get
         _ -> fail "problem getting Opt.Main binary"
 
 instance Binary Node where

--- a/compiler/src/Generate/JavaScript.hs
+++ b/compiler/src/Generate/JavaScript.hs
@@ -54,12 +54,10 @@ perfNote mode =
     Mode.Prod _ ->
       ""
     Mode.Dev Nothing ->
-      "console.warn('Compiled in DEV mode. Follow the advice at "
-        <> B.stringUtf8 (D.makeNakedLink "optimize")
+      "console.warn('Compiled in DEV mode. Compile with --optimize "
         <> " for better performance and smaller assets.');"
     Mode.Dev (Just _) ->
-      "console.warn('Compiled in DEBUG mode. Follow the advice at "
-        <> B.stringUtf8 (D.makeNakedLink "optimize")
+      "console.warn('Compiled in DEV mode. Compile with --optimize "
         <> " for better performance and smaller assets.');"
 
 -- GENERATE FOR REPL

--- a/compiler/src/Generate/JavaScript.hs
+++ b/compiler/src/Generate/JavaScript.hs
@@ -42,7 +42,7 @@ generate mode (Opt.GlobalGraph graph _) mains =
         <> perfNote mode
         <> stateToBuilder state
         <> toMainExports mode mains
-        <> "}(this));"
+        <> "}(this.module ? this.module.exports : this));"
 
 addMain :: Mode.Mode -> Graph -> ModuleName.Canonical -> Opt.Main -> State -> State
 addMain mode graph home _ state =

--- a/compiler/src/Generate/JavaScript.hs
+++ b/compiler/src/Generate/JavaScript.hs
@@ -3,7 +3,6 @@
 module Generate.JavaScript
   ( generate,
     generateForRepl,
-    generateForReplEndpoint,
   )
 where
 
@@ -99,39 +98,6 @@ print ansi localizer home name tipe =
            \} else {\n\
            \    _print(' : ' + _type);\n\
            \}\n"
-
--- GENERATE FOR REPL ENDPOINT
-
-generateForReplEndpoint :: L.Localizer -> Opt.GlobalGraph -> ModuleName.Canonical -> Maybe Name.Name -> Can.Annotation -> B.Builder
-generateForReplEndpoint localizer (Opt.GlobalGraph graph _) home maybeName (Can.Forall _ tipe) =
-  let name = maybe Name.replValueToPrint id maybeName
-      mode = Mode.Dev Nothing
-      debugState = addGlobal mode graph emptyState (Opt.Global ModuleName.debug "toString")
-      evalState = addGlobal mode graph debugState (Opt.Global home name)
-   in Functions.functions
-        <> stateToBuilder evalState
-        <> postMessage localizer home maybeName tipe
-
-postMessage :: L.Localizer -> ModuleName.Canonical -> Maybe Name.Name -> Can.Type -> B.Builder
-postMessage localizer home maybeName tipe =
-  let name = maybe Name.replValueToPrint id maybeName
-      value = JsName.toBuilder (JsName.fromGlobal home name)
-      toString = JsName.toBuilder (JsName.fromKernel Name.debug "toAnsiString")
-      tipeDoc = RT.canToDoc localizer RT.None tipe
-      toName n = "\"" <> Name.toBuilder n <> "\""
-   in "self.postMessage({\n\
-      \  name: "
-        <> maybe "null" toName maybeName
-        <> ",\n\
-           \  value: "
-        <> toString
-        <> "(true, "
-        <> value
-        <> "),\n\
-           \  type: "
-        <> B.stringUtf8 (show (D.toString tipeDoc))
-        <> "\n\
-           \});\n"
 
 -- GRAPH TRAVERSAL STATE
 

--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -492,8 +492,8 @@ generateTailCall mode name args =
       toRealVars (argName, _) =
         JS.ExprStmt $
           JS.Assign (JS.LRef (JsName.fromLocal argName)) (JS.Ref (JsName.makeTemp argName))
-   in JS.Vars (map toTempVars args)
-        : map toRealVars args
+   in JS.Vars (map toTempVars args) :
+      map toRealVars args
         ++ [JS.Continue (Just (JsName.fromLocal name))]
 
 -- DEFINITIONS
@@ -749,7 +749,10 @@ pathToJsExpr mode root path =
 generateMain :: Mode.Mode -> ModuleName.Canonical -> Opt.Main -> JS.Expr
 generateMain mode home main =
   case main of
-    Opt.Static ->
+    Opt.StaticString ->
+      JS.Ref (JsName.fromKernel Name.node "log")
+        # JS.Ref (JsName.fromGlobal home "main")
+    Opt.StaticVDom ->
       JS.Ref (JsName.fromKernel Name.virtualDom "init")
         # JS.Ref (JsName.fromGlobal home "main")
         # JS.Int 0

--- a/compiler/src/Generate/JavaScript/Expression.hs
+++ b/compiler/src/Generate/JavaScript/Expression.hs
@@ -492,8 +492,8 @@ generateTailCall mode name args =
       toRealVars (argName, _) =
         JS.ExprStmt $
           JS.Assign (JS.LRef (JsName.fromLocal argName)) (JS.Ref (JsName.makeTemp argName))
-   in JS.Vars (map toTempVars args) :
-      map toRealVars args
+   in JS.Vars (map toTempVars args)
+        : map toRealVars args
         ++ [JS.Continue (Just (JsName.fromLocal name))]
 
 -- DEFINITIONS

--- a/compiler/src/Generate/Node.hs
+++ b/compiler/src/Generate/Node.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Generate.Node
+  ( sandwich,
+  )
+where
+
+import Data.ByteString.Builder qualified as B
+import Data.Name qualified as Name
+import Text.RawString.QQ (r)
+
+-- SANDWICH
+
+sandwich :: Name.Name -> B.Builder -> B.Builder
+sandwich moduleName javascript =
+  let name = Name.toBuilder moduleName
+   in [r|#!/usr/bin/env node
+
+try {
+|]
+        <> javascript
+        <> [r|
+|]
+        <> [r|this.Gren.|]
+        <> name
+        <> [r|.init({});
+}
+catch (e)
+{
+console.error(e);
+}
+|]

--- a/compiler/src/Optimize/Module.hs
+++ b/compiler/src/Optimize/Module.hs
@@ -177,13 +177,13 @@ addDefHelp platform region annotations home name args body graph@(Opt.LocalGraph
                   Result.ok $
                     addMain $
                       Names.run $
-                        Names.registerKernel Name.virtualDom Opt.Static
+                        Names.registerKernel Name.node Opt.StaticString
             Can.TType hm nm [_]
               | platform == P.Browser && hm == ModuleName.virtualDom && nm == Name.node ->
                   Result.ok $
                     addMain $
                       Names.run $
-                        Names.registerKernel Name.virtualDom Opt.Static
+                        Names.registerKernel Name.virtualDom Opt.StaticVDom
             Can.TType hm nm [flags, _, message] | hm == ModuleName.platform && nm == Name.program ->
               case Effects.checkPayload flags of
                 Right () ->

--- a/compiler/src/Optimize/Module.hs
+++ b/compiler/src/Optimize/Module.hs
@@ -172,14 +172,14 @@ addDefHelp platform region annotations home name args body graph@(Opt.LocalGraph
             addDefNode home name args body deps $
               Opt.LocalGraph (Just main) nodes (Map.unionWith (+) fields fieldCounts)
        in case Type.deepDealias tipe of
-            Can.TType hm nm [_]
-              | platform == P.Browser && hm == ModuleName.virtualDom && nm == Name.node ->
+            Can.TType hm nm []
+              | platform == P.Node && hm == ModuleName.string && nm == Name.string ->
                   Result.ok $
                     addMain $
                       Names.run $
                         Names.registerKernel Name.virtualDom Opt.Static
             Can.TType hm nm [_]
-              | platform == P.Node && hm == ModuleName.string && nm == Name.string ->
+              | platform == P.Browser && hm == ModuleName.virtualDom && nm == Name.node ->
                   Result.ok $
                     addMain $
                       Names.run $
@@ -194,7 +194,10 @@ addDefHelp platform region annotations home name args body graph@(Opt.LocalGraph
                 Left (subType, invalidPayload) ->
                   Result.throw (E.BadFlags region subType invalidPayload)
             _ ->
-              Result.throw (E.BadType region tipe)
+              case platform of
+                P.Browser -> Result.throw (E.BadType region tipe ["Html", "Svg", "Program"])
+                P.Node -> Result.throw (E.BadType region tipe ["String", "Program"])
+                P.Common -> Result.throw (E.BadType region tipe [])
 
 addDefNode :: ModuleName.Canonical -> Name.Name -> [Can.Pattern] -> Can.Expr -> Set.Set Opt.Global -> Opt.LocalGraph -> Opt.LocalGraph
 addDefNode home name args body mainDeps graph =

--- a/compiler/src/Optimize/Module.hs
+++ b/compiler/src/Optimize/Module.hs
@@ -17,6 +17,7 @@ import Data.Map qualified as Map
 import Data.Name qualified as Name
 import Data.Set qualified as Set
 import Gren.ModuleName qualified as ModuleName
+import Gren.Platform qualified as P
 import Optimize.Expression qualified as Expr
 import Optimize.Names qualified as Names
 import Optimize.Port qualified as Port
@@ -34,9 +35,9 @@ type Result i w a =
 type Annotations =
   Map.Map Name.Name Can.Annotation
 
-optimize :: Annotations -> Can.Module -> Result i [W.Warning] Opt.LocalGraph
-optimize annotations (Can.Module home _ _ decls unions _ _ effects) =
-  addDecls home annotations decls $
+optimize :: P.Platform -> Annotations -> Can.Module -> Result i [W.Warning] Opt.LocalGraph
+optimize platform annotations (Can.Module home _ _ decls unions _ _ effects) =
+  addDecls platform home annotations decls $
     addEffects home effects $
       addUnions home unions $
         Opt.LocalGraph Nothing Map.empty Map.empty
@@ -114,16 +115,16 @@ addToGraph name node fields (Opt.LocalGraph main nodes fieldCounts) =
 
 -- ADD DECLS
 
-addDecls :: ModuleName.Canonical -> Annotations -> Can.Decls -> Opt.LocalGraph -> Result i [W.Warning] Opt.LocalGraph
-addDecls home annotations decls graph =
+addDecls :: P.Platform -> ModuleName.Canonical -> Annotations -> Can.Decls -> Opt.LocalGraph -> Result i [W.Warning] Opt.LocalGraph
+addDecls platform home annotations decls graph =
   case decls of
     Can.Declare def subDecls ->
-      addDecls home annotations subDecls =<< addDef home annotations def graph
+      addDecls platform home annotations subDecls =<< addDef platform home annotations def graph
     Can.DeclareRec d ds subDecls ->
       let defs = d : ds
        in case findMain defs of
             Nothing ->
-              addDecls home annotations subDecls (addRecDefs home defs graph)
+              addDecls platform home annotations subDecls (addRecDefs home defs graph)
             Just region ->
               Result.throw $ E.BadCycle region (defToName d) (map defToName ds)
     Can.SaveTheEnvironment ->
@@ -149,19 +150,19 @@ defToName def =
 
 -- ADD DEFS
 
-addDef :: ModuleName.Canonical -> Annotations -> Can.Def -> Opt.LocalGraph -> Result i [W.Warning] Opt.LocalGraph
-addDef home annotations def graph =
+addDef :: P.Platform -> ModuleName.Canonical -> Annotations -> Can.Def -> Opt.LocalGraph -> Result i [W.Warning] Opt.LocalGraph
+addDef platform home annotations def graph =
   case def of
     Can.Def (A.At region name) args body ->
       do
         let (Can.Forall _ tipe) = annotations ! name
         Result.warn $ W.MissingTypeAnnotation region name tipe
-        addDefHelp region annotations home name args body graph
+        addDefHelp platform region annotations home name args body graph
     Can.TypedDef (A.At region name) _ typedArgs body _ ->
-      addDefHelp region annotations home name (map fst typedArgs) body graph
+      addDefHelp platform region annotations home name (map fst typedArgs) body graph
 
-addDefHelp :: A.Region -> Annotations -> ModuleName.Canonical -> Name.Name -> [Can.Pattern] -> Can.Expr -> Opt.LocalGraph -> Result i w Opt.LocalGraph
-addDefHelp region annotations home name args body graph@(Opt.LocalGraph _ nodes fieldCounts) =
+addDefHelp :: P.Platform -> A.Region -> Annotations -> ModuleName.Canonical -> Name.Name -> [Can.Pattern] -> Can.Expr -> Opt.LocalGraph -> Result i w Opt.LocalGraph
+addDefHelp platform region annotations home name args body graph@(Opt.LocalGraph _ nodes fieldCounts) =
   if name /= Name._main
     then Result.ok (addDefNode home name args body Set.empty graph)
     else
@@ -172,7 +173,13 @@ addDefHelp region annotations home name args body graph@(Opt.LocalGraph _ nodes 
               Opt.LocalGraph (Just main) nodes (Map.unionWith (+) fields fieldCounts)
        in case Type.deepDealias tipe of
             Can.TType hm nm [_]
-              | hm == ModuleName.virtualDom && nm == Name.node ->
+              | platform == P.Browser && hm == ModuleName.virtualDom && nm == Name.node ->
+                  Result.ok $
+                    addMain $
+                      Names.run $
+                        Names.registerKernel Name.virtualDom Opt.Static
+            Can.TType hm nm [_]
+              | platform == P.Node && hm == ModuleName.string && nm == Name.string ->
                   Result.ok $
                     addMain $
                       Names.run $

--- a/compiler/src/Reporting/Error/Main.hs
+++ b/compiler/src/Reporting/Error/Main.hs
@@ -8,6 +8,7 @@ module Reporting.Error.Main
 where
 
 import AST.Canonical qualified as Can
+import Data.List qualified as List
 import Data.Name qualified as Name
 import Reporting.Annotation qualified as A
 import Reporting.Doc qualified as D
@@ -20,7 +21,7 @@ import Reporting.Report qualified as Report
 -- ERROR
 
 data Error
-  = BadType A.Region Can.Type
+  = BadType A.Region Can.Type [String]
   | BadCycle A.Region Name.Name [Name.Name]
   | BadFlags A.Region Can.Type E.InvalidPayload
 
@@ -29,7 +30,7 @@ data Error
 toReport :: L.Localizer -> Code.Source -> Error -> Report.Report
 toReport localizer source err =
   case err of
-    BadType region tipe ->
+    BadType region tipe allowed ->
       Report.Report "BAD MAIN TYPE" region [] $
         Code.toSnippet
           source
@@ -39,9 +40,7 @@ toReport localizer source err =
             D.stack
               [ "The type of `main` value I am seeing is:",
                 D.indent 4 $ D.dullyellow $ RT.canToDoc localizer RT.None tipe,
-                D.reflow $
-                  "I only know how to handle Html, Svg, and Programs\
-                  \ though. Modify `main` to be one of those types of values!"
+                D.reflow $ "But I only know how to handle these types: " ++ List.intercalate ", " allowed
               ]
           )
     BadCycle region name names ->

--- a/gren.cabal
+++ b/gren.cabal
@@ -134,6 +134,7 @@ Common gren-common
         Canonicalize.Type
         Compile
         Generate.Html
+        Generate.Node
         Generate.JavaScript
         Generate.JavaScript.Builder
         Generate.JavaScript.Expression

--- a/terminal/src/Diff.hs
+++ b/terminal/src/Diff.hs
@@ -154,9 +154,9 @@ generateDocs (Env maybeRoot _) =
               Details.load Reporting.silent scope root
 
         case Details._outline details of
-          Details.ValidApp _ ->
+          Details.ValidApp _ _ ->
             Task.throw Exit.DiffApplication
-          Details.ValidPkg _ exposed ->
+          Details.ValidPkg _ _ exposed ->
             case exposed of
               [] ->
                 Task.throw Exit.DiffNoExposed

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -142,9 +142,9 @@ getMode debug optimize =
 getExposed :: Details.Details -> Task (NE.List ModuleName.Raw)
 getExposed (Details.Details _ validOutline _ _ _ _) =
   case validOutline of
-    Details.ValidApp _ ->
+    Details.ValidApp _ _ ->
       Task.throw Exit.MakeAppNeedsFileNames
-    Details.ValidPkg _ exposed ->
+    Details.ValidPkg _ _ exposed ->
       case exposed of
         [] -> Task.throw Exit.MakePkgNeedsExposing
         m : ms -> return (NE.List m ms)

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -21,6 +21,7 @@ import Directories qualified as Dirs
 import File qualified
 import Generate qualified
 import Generate.Html qualified as Html
+import Generate.Node qualified as Node
 import Gren.Details qualified as Details
 import Gren.ModuleName qualified as ModuleName
 import Gren.Outline qualified as Outline
@@ -92,6 +93,10 @@ runHelp root paths style (Flags debug optimize maybeOutput _ maybeDocs) =
                         do
                           builder <- toBuilder root details desiredMode artifacts
                           generate style "index.html" (Html.sandwich name builder) (NE.List name [])
+                      (Platform.Node, [name]) ->
+                        do
+                          builder <- toBuilder root details desiredMode artifacts
+                          generate style "gren.js" (Node.sandwich name builder) (NE.List name [])
                       (_, name : names) ->
                         do
                           builder <- toBuilder root details desiredMode artifacts

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -114,9 +114,13 @@ runHelp root paths style (Flags debug optimize maybeOutput _ maybeDocs) =
                   Just (JS target) ->
                     case getNoMains artifacts of
                       [] ->
-                        do
-                          builder <- toBuilder root details desiredMode artifacts
-                          generate style target builder (Build.getRootNames artifacts)
+                        case (platform, getMains artifacts) of
+                          (Platform.Node, [name]) -> do
+                            builder <- toBuilder root details desiredMode artifacts
+                            generate style target (Node.sandwich name builder) (Build.getRootNames artifacts)
+                          _ -> do
+                            builder <- toBuilder root details desiredMode artifacts
+                            generate style target builder (Build.getRootNames artifacts)
                       name : names ->
                         Task.throw (Exit.MakeNonMainFilesIntoJavaScript name names)
                   Just (Html target) ->

--- a/terminal/src/Publish.hs
+++ b/terminal/src/Publish.hs
@@ -138,9 +138,9 @@ verifyBuild root =
 
           exposed <-
             case outline of
-              Details.ValidApp _ -> Task.throw Exit.PublishApplication
-              Details.ValidPkg _ [] -> Task.throw Exit.PublishNoExposed
-              Details.ValidPkg _ (e : es) -> return (NE.List e es)
+              Details.ValidApp _ _ -> Task.throw Exit.PublishApplication
+              Details.ValidPkg _ _ [] -> Task.throw Exit.PublishNoExposed
+              Details.ValidPkg _ _ (e : es) -> return (NE.List e es)
 
           Task.eio Exit.PublishBuildProblem $
             Build.fromExposed Reporting.silent root details Build.KeepDocs exposed


### PR DESCRIPTION
This adds support for compiling applications that target the `node` platform.

It adds a couple of changes:

1. When the platform is `node`, `main` functions can have a `String` signature.
2. When leaving off the extension of a filename, it generates a file with a shebang line, so that the file can be executed directly on unix systems.
3. You can now import a compiled `.js` file into Node, and it will contain a Gren property with all exported main functions.
4. Error messages have been updated accordingly.

`String` returning main functions works as expected. Full programs probably don't, but it's hard to test this until we have a more advanced platform package.