### PR TITLE
Create a new docs command, and remove the --docs flag from make.

### DIFF
--- a/gren.cabal
+++ b/gren.cabal
@@ -57,6 +57,7 @@ Common gren-common
         Init
         Install
         Make
+        Docs
         Publish
         Repl
 

--- a/terminal/src/Docs.hs
+++ b/terminal/src/Docs.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Docs
+  ( Flags (..),
+    Output (..),
+    ReportType (..),
+    run,
+    reportType,
+    output,
+    docsFile,
+  )
+where
+
+import BackgroundWriter qualified as BW
+import Build qualified
+import Data.ByteString.Builder qualified as B
+import Data.NonEmptyList qualified as NE
+import Directories qualified as Dirs
+import Gren.Details qualified as Details
+import Gren.Docs qualified as Docs
+import Gren.ModuleName qualified as ModuleName
+import Json.Encode qualified as Json
+import Reporting qualified
+import Reporting.Exit qualified as Exit
+import Reporting.Task qualified as Task
+import System.FilePath qualified as FP
+import System.IO qualified as IO
+import Terminal (Parser (..))
+
+-- FLAGS
+
+data Flags = Flags
+  { _output :: Maybe Output,
+    _report :: Maybe ReportType
+  }
+
+data Output
+  = JSON FilePath
+  | DevNull
+  | DevStdOut
+
+data ReportType
+  = Json
+
+-- RUN
+
+type Task a = Task.Task Exit.Make a
+
+run :: () -> Flags -> IO ()
+run () flags@(Flags _ report) =
+  do
+    style <- getStyle report
+    maybeRoot <- Dirs.findRoot
+    Reporting.attemptWithStyle style Exit.makeToReport $
+      case maybeRoot of
+        Just root -> runHelp root style flags
+        Nothing -> return $ Left $ Exit.MakeNoOutline
+
+runHelp :: FilePath -> Reporting.Style -> Flags -> IO (Either Exit.Make ())
+runHelp root style (Flags maybeOutput _) =
+  BW.withScope $ \scope ->
+    Dirs.withRootLock root $
+      Task.run $
+        do
+          details <- Task.eio Exit.MakeBadDetails (Details.load style scope root)
+          exposed <- getExposed details
+          case maybeOutput of
+            Just DevNull ->
+              do
+                buildExposed style root details Build.IgnoreDocs exposed
+                return ()
+            Just DevStdOut ->
+              do
+                docs <- buildExposed style root details Build.KeepDocs exposed
+                let builder = Json.encodeUgly $ Docs.encode docs
+                Task.io $ B.hPutBuilder IO.stdout builder
+            Nothing ->
+              buildExposed style root details (Build.WriteDocs "docs.json") exposed
+            Just (JSON target) ->
+              buildExposed style root details (Build.WriteDocs target) exposed
+
+-- GET INFORMATION
+
+getStyle :: Maybe ReportType -> IO Reporting.Style
+getStyle report =
+  case report of
+    Nothing -> Reporting.terminal
+    Just Json -> return Reporting.json
+
+getExposed :: Details.Details -> Task (NE.List ModuleName.Raw)
+getExposed (Details.Details _ validOutline _ _ _ _) =
+  case validOutline of
+    Details.ValidApp _ _ ->
+      Task.throw Exit.MakeAppNeedsFileNames
+    Details.ValidPkg _ _ exposed ->
+      case exposed of
+        [] -> Task.throw Exit.MakePkgNeedsExposing
+        m : ms -> return (NE.List m ms)
+
+-- BUILD PROJECTS
+
+buildExposed :: Reporting.Style -> FilePath -> Details.Details -> Build.DocsGoal a -> NE.List ModuleName.Raw -> Task a
+buildExposed style root details docsGoal exposed =
+  Task.eio Exit.MakeCannotBuild $
+    Build.fromExposed style root details docsGoal exposed
+
+-- PARSERS
+
+reportType :: Parser ReportType
+reportType =
+  Parser
+    { _singular = "report type",
+      _plural = "report types",
+      _parser = \string -> if string == "json" then Just Json else Nothing,
+      _suggest = \_ -> return ["json"],
+      _examples = \_ -> return ["json"]
+    }
+
+output :: Parser Output
+output =
+  Parser
+    { _singular = "output file",
+      _plural = "output files",
+      _parser = parseOutput,
+      _suggest = \_ -> return [],
+      _examples = \_ -> return ["gren.js", "index.html", "/dev/null", "/dev/stdout"]
+    }
+
+parseOutput :: String -> Maybe Output
+parseOutput name
+  | name == "/dev/stdout" = Just DevStdOut
+  | isDevNull name = Just DevNull
+  | hasExt ".json" name = Just (JSON name)
+  | otherwise = Nothing
+
+docsFile :: Parser FilePath
+docsFile =
+  Parser
+    { _singular = "json file",
+      _plural = "json files",
+      _parser = \name -> if hasExt ".json" name then Just name else Nothing,
+      _suggest = \_ -> return [],
+      _examples = \_ -> return ["docs.json", "documentation.json"]
+    }
+
+hasExt :: String -> String -> Bool
+hasExt ext path =
+  FP.takeExtension path == ext && length path > length ext
+
+isDevNull :: String -> Bool
+isDevNull name =
+  name == "/dev/null" || name == "NUL" || name == "$null"

--- a/terminal/src/Main.hs
+++ b/terminal/src/Main.hs
@@ -8,6 +8,7 @@ where
 import Bump qualified
 import Data.List qualified as List
 import Diff qualified
+import Docs qualified
 import Format qualified
 import Gren.Platform qualified as Platform
 import Gren.Version qualified as V
@@ -31,6 +32,7 @@ main =
     [ repl,
       init,
       make,
+      docs,
       install,
       format,
       bump,
@@ -155,8 +157,30 @@ make =
           |-- onOff "optimize" "Turn on optimizations to make code smaller and faster. For example, the compiler renames record fields to be as short as possible and unboxes values to reduce allocation."
           |-- flag "output" Make.output "Specify the name of the resulting JS file. For example --output=assets/gren.js to generate the JS at assets/gren.js. You can also use --output=/dev/stdout to output the JS to the terminal, or --output=/dev/null to generate no output at all!"
           |-- flag "report" Make.reportType "You can say --report=json to get error messages as JSON. This is only really useful if you are an editor plugin. Humans should avoid it!"
-          |-- flag "docs" Make.docsFile "Generate a JSON file of documentation for a package."
    in Terminal.Command "make" Uncommon details example (zeroOrMore grenFile) makeFlags Make.run
+
+-- DOCS
+
+docs :: Terminal.Command
+docs =
+  let details =
+        "The `docs` command collects all documentation for a package in a JSON file:"
+
+      example =
+        stack
+          [ reflow
+              "For example:",
+            P.indent 4 $ P.green "gren docs",
+            reflow
+              "This collects all documentation for the current package and writes it to a\
+              \ docs.json file, if possible"
+          ]
+
+      docsFlags =
+        flags Docs.Flags
+          |-- flag "output" Docs.output "Specify the name of the resulting JSON file. For example --output=assets/docs.json to generate the JSON at assets/docs.json. You can also use --output=/dev/stdout to output the JSON to the terminal, or --output=/dev/null to verify that generating the documentation would work."
+          |-- flag "report" Docs.reportType "You can say --report=json to get error messages as JSON. This is only really useful if you are an editor plugin. Humans should avoid it!"
+   in Terminal.Command "docs" Uncommon details example noArgs docsFlags Docs.run
 
 -- INSTALL
 
@@ -284,8 +308,8 @@ format =
 -- HELPERS
 
 stack :: [P.Doc] -> P.Doc
-stack docs =
-  P.vcat $ List.intersperse "" docs
+stack docList =
+  P.vcat $ List.intersperse "" docList
 
 reflow :: String -> P.Doc
 reflow string =


### PR DESCRIPTION
Creating a json file with a project's documentation is now a seperate command. This also allows for outputting the documentation to stdout instead of to a file, which can simplify external tools.