### PR TITLE
Formatting retains comments (module header and paren expressions)

### DIFF
--- a/builder/src/Build.hs
+++ b/builder/src/Build.hs
@@ -267,7 +267,7 @@ crawlFile env@(Env _ root projectType _ buildID _ _) mvar docsNeed expectedName 
     case Parse.fromByteString projectType source of
       Left err ->
         return $ SBadSyntax path time source err
-      Right modul@(Src.Module maybeActualName _ _ imports values _ _ _ _) ->
+      Right modul@(Src.Module maybeActualName _ _ imports values _ _ _ _ _) ->
         case maybeActualName of
           Nothing ->
             return $ SBadSyntax path time source (Syntax.ModuleNameUnspecified expectedName)
@@ -333,11 +333,11 @@ checkModule env@(Env _ root projectType _ _ _ _) foreigns resultsMVar name statu
                 RProblem $
                   Error.Module name path time source $
                     case Parse.fromByteString projectType source of
-                      Right (Src.Module _ _ _ imports _ _ _ _ _) ->
+                      Right (Src.Module _ _ _ imports _ _ _ _ _ _) ->
                         Error.BadImports (toImportErrors env results imports problems)
                       Left err ->
                         Error.BadSyntax err
-    SChanged local@(Details.Local path time deps _ _ lastCompile) source modul@(Src.Module _ _ _ imports _ _ _ _ _) docsNeed ->
+    SChanged local@(Details.Local path time deps _ _ lastCompile) source modul@(Src.Module _ _ _ imports _ _ _ _ _ _) docsNeed ->
       do
         results <- readMVar resultsMVar
         depsStatus <- checkDeps root results deps lastCompile
@@ -758,7 +758,7 @@ fromRepl root details source =
     case Parse.fromByteString projectType source of
       Left syntaxError ->
         return $ Left $ Exit.ReplBadInput source $ Error.BadSyntax syntaxError
-      Right modul@(Src.Module _ _ _ imports _ _ _ _ _) ->
+      Right modul@(Src.Module _ _ _ imports _ _ _ _ _ _) ->
         do
           dmvar <- Details.loadInterfaces root details
 
@@ -783,7 +783,7 @@ fromRepl root details source =
                 finalizeReplArtifacts env source modul depsStatus resultMVars results
 
 finalizeReplArtifacts :: Env -> B.ByteString -> Src.Module -> DepsStatus -> ResultDict -> Map.Map ModuleName.Raw Result -> IO (Either Exit.Repl ReplArtifacts)
-finalizeReplArtifacts env@(Env _ root projectType _ _ _ _) source modul@(Src.Module _ _ _ imports _ _ _ _ _) depsStatus resultMVars results =
+finalizeReplArtifacts env@(Env _ root projectType _ _ _ _) source modul@(Src.Module _ _ _ imports _ _ _ _ _ _) depsStatus resultMVars results =
   let pkg =
         projectTypeToPkg projectType
 
@@ -948,7 +948,7 @@ crawlRoot env@(Env _ _ projectType _ buildID _ _) mvar root =
         time <- File.getTime path
         source <- File.readUtf8 path
         case Parse.fromByteString projectType source of
-          Right modul@(Src.Module _ _ _ imports values _ _ _ _) ->
+          Right modul@(Src.Module _ _ _ imports values _ _ _ _ _) ->
             do
               let deps = map Src.getImportName imports
               let local = Details.Local path time deps (any isMain values) buildID buildID
@@ -973,7 +973,7 @@ checkRoot env@(Env _ root _ _ _ _ _) results rootStatus =
       return (RInside name)
     SOutsideErr err ->
       return (ROutsideErr err)
-    SOutsideOk local@(Details.Local path time deps _ _ lastCompile) source modul@(Src.Module _ _ _ imports _ _ _ _ _) ->
+    SOutsideOk local@(Details.Local path time deps _ _ lastCompile) source modul@(Src.Module _ _ _ imports _ _ _ _ _ _) ->
       do
         depsStatus <- checkDeps root results deps lastCompile
         case depsStatus of

--- a/builder/src/Gren/Details.hs
+++ b/builder/src/Gren/Details.hs
@@ -489,7 +489,7 @@ crawlFile foreignDeps mvar pkg src docsStatus expectedName path =
   do
     bytes <- File.readUtf8 path
     case Parse.fromByteString (Parse.Package pkg) bytes of
-      Right modul@(Src.Module (Just (A.At _ actualName)) _ _ imports _ _ _ _ _) | expectedName == actualName ->
+      Right modul@(Src.Module (Just (A.At _ actualName)) _ _ imports _ _ _ _ _ _) | expectedName == actualName ->
         do
           deps <- crawlImports foreignDeps mvar pkg src imports
           return (Just (SLocal docsStatus deps modul))

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -34,23 +34,15 @@ module AST.Source
   )
 where
 
+import AST.SourceComments (Comment, GREN_COMMENT)
+import AST.SourceComments qualified as SC
 import AST.Utils.Binop qualified as Binop
 import Data.Name (Name)
 import Data.Name qualified as Name
-import Data.Utf8 qualified as Utf8
 import Gren.Float qualified as EF
 import Gren.String qualified as ES
 import Parse.Primitives qualified as P
 import Reporting.Annotation qualified as A
-
--- COMMENTS
-
-data Comment
-  = BlockComment (Utf8.Utf8 GREN_COMMENT)
-  | LineComment (Utf8.Utf8 GREN_COMMENT)
-  deriving (Show)
-
-data GREN_COMMENT
 
 -- EXPRESSIONS
 
@@ -183,9 +175,9 @@ data Effects
   deriving (Show)
 
 data Manager
-  = Cmd (A.Located Name)
-  | Sub (A.Located Name)
-  | Fx (A.Located Name) (A.Located Name)
+  = Cmd (A.Located Name) SC.CmdComments
+  | Sub (A.Located Name) SC.SubComments
+  | Fx (A.Located Name) (A.Located Name) SC.FxComments
   deriving (Show)
 
 data Docs

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -129,7 +129,7 @@ data Module = Module
     _unions :: [(SourceOrder, A.Located Union)],
     _aliases :: [(SourceOrder, A.Located Alias)],
     _binops :: [A.Located Infix],
-    _comments :: [A.Located [Comment]],
+    _headerComments :: SC.HeaderComments,
     _effects :: Effects
   }
   deriving (Show)
@@ -170,8 +170,8 @@ data Port = Port (A.Located Name) Type
 
 data Effects
   = NoEffects
-  | Ports [(SourceOrder, Port)]
-  | Manager A.Region Manager
+  | Ports [(SourceOrder, Port)] SC.PortsComments
+  | Manager A.Region Manager SC.ManagerComments
   deriving (Show)
 
 data Manager

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -125,11 +125,12 @@ data Module = Module
     _unions :: [A.Located Union],
     _aliases :: [A.Located Alias],
     _binops :: [A.Located Infix],
+    _comments :: [A.Located [Comment]],
     _effects :: Effects
   }
 
 getName :: Module -> Name
-getName (Module maybeName _ _ _ _ _ _ _ _) =
+getName (Module maybeName _ _ _ _ _ _ _ _ _) =
   case maybeName of
     Just (A.At _ name) ->
       name

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -72,6 +72,7 @@ data Expr_
   | Access Expr (A.Located Name)
   | Update (A.Located Name) [(A.Located Name, Expr)]
   | Record [(A.Located Name, Expr)]
+  | Parens [Comment] Expr [Comment]
 
 data VarType = LowVar | CapVar
 

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -1,0 +1,30 @@
+module AST.SourceComments where
+
+import Data.Utf8 qualified as Utf8
+
+data GREN_COMMENT
+
+data Comment
+  = BlockComment (Utf8.Utf8 GREN_COMMENT)
+  | LineComment (Utf8.Utf8 GREN_COMMENT)
+  deriving (Show)
+
+-- Manager
+
+data CmdComments = CmdComments
+  { _beforeCommandKeyword :: [Comment],
+    _afterCommand :: [Comment]
+  }
+  deriving (Show)
+
+data SubComments = SubComments
+  { _beforeSubscriptionsKeyword :: [Comment],
+    _afterSubscriptions :: [Comment]
+  }
+  deriving (Show)
+
+data FxComments = FxComments
+  { _cmdComments :: CmdComments,
+    _subComments :: SubComments
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -9,6 +9,32 @@ data Comment
   | LineComment (Utf8.Utf8 GREN_COMMENT)
   deriving (Show)
 
+-- Module
+
+data HeaderComments = HeaderComments
+  { _beforeModuleLine :: [Comment],
+    _afterModuleKeyword :: [Comment],
+    _afterModuleName :: [Comment],
+    _afterExposingKeyword :: [Comment],
+    _afterModuleLine :: [Comment],
+    _afterModuleDocComment :: [Comment]
+  }
+  deriving (Show)
+
+-- Effects
+
+data PortsComments = PortsComments
+  { _afterPortKeyword :: [Comment]
+  }
+  deriving (Show)
+
+data ManagerComments = ManagerComments
+  { _afterEffectKeyword :: [Comment],
+    _afterWhereKeyword :: [Comment],
+    _afterManager :: [Comment]
+  }
+  deriving (Show)
+
 -- Manager
 
 data CmdComments = CmdComments

--- a/compiler/src/Canonicalize/Effects.hs
+++ b/compiler/src/Canonicalize/Effects.hs
@@ -48,15 +48,15 @@ canonicalize env values unions effects =
             <*> verifyManager region dict "onEffects"
             <*> verifyManager region dict "onSelfMsg"
             <*> case manager of
-              Src.Cmd cmdType ->
+              Src.Cmd cmdType _ ->
                 Can.Cmd
                   <$> verifyEffectType cmdType unions
                   <* verifyManager region dict "cmdMap"
-              Src.Sub subType ->
+              Src.Sub subType _ ->
                 Can.Sub
                   <$> verifyEffectType subType unions
                   <* verifyManager region dict "subMap"
-              Src.Fx cmdType subType ->
+              Src.Fx cmdType subType _ ->
                 Can.Fx
                   <$> verifyEffectType cmdType unions
                   <*> verifyEffectType subType unions

--- a/compiler/src/Canonicalize/Effects.hs
+++ b/compiler/src/Canonicalize/Effects.hs
@@ -37,11 +37,11 @@ canonicalize env values unions effects =
   case effects of
     Src.NoEffects ->
       Result.ok Can.NoEffects
-    Src.Ports ports ->
+    Src.Ports ports _ ->
       do
         pairs <- traverse (canonicalizePort env) (fmap snd ports)
         return $ Can.Ports (Map.fromList pairs)
-    Src.Manager region manager ->
+    Src.Manager region manager _ ->
       let dict = Map.fromList (map toNameRegion values)
        in Can.Manager
             <$> verifyManager region dict "init"

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -57,11 +57,11 @@ toEffectDups effects =
   case effects of
     Src.NoEffects ->
       Dups.none
-    Src.Ports ports ->
+    Src.Ports ports _ ->
       let addPort dict (Src.Port (A.At region name) _) =
             Dups.insert name region (Env.TopLevel region) dict
        in List.foldl' addPort Dups.none (fmap snd ports)
-    Src.Manager _ manager ->
+    Src.Manager _ manager _ ->
       case manager of
         Src.Cmd (A.At region _) _ ->
           Dups.one "command" region (Env.TopLevel region)

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -46,7 +46,7 @@ addVars module_ (Env.Env home vs ts cs bs qvs qts qcs) =
     Result.ok $ Env.Env home vs2 ts cs bs qvs qts qcs
 
 collectVars :: Src.Module -> Result i w (Map.Map Name.Name Env.Var)
-collectVars (Src.Module _ _ _ _ values _ _ _ effects) =
+collectVars (Src.Module _ _ _ _ values _ _ _ _ effects) =
   let addDecl dict (A.At _ (Src.Value (A.At region name) _ _ _)) =
         Dups.insert name region (Env.TopLevel region) dict
    in Dups.detect Error.DuplicateDecl $
@@ -75,7 +75,7 @@ toEffectDups effects =
 -- ADD TYPES
 
 addTypes :: Src.Module -> Env.Env -> Result i w Env.Env
-addTypes (Src.Module _ _ _ _ _ unions aliases _ _) (Env.Env home vs ts cs bs qvs qts qcs) =
+addTypes (Src.Module _ _ _ _ _ unions aliases _ _ _) (Env.Env home vs ts cs bs qvs qts qcs) =
   let addAliasDups dups (A.At _ (Src.Alias (A.At region name) _ _)) = Dups.insert name region () dups
       addUnionDups dups (A.At _ (Src.Union (A.At region name) _ _)) = Dups.insert name region () dups
       typeNameDups =
@@ -199,7 +199,7 @@ addFreeVars freeVars (A.At region tipe) =
 -- ADD CTORS
 
 addCtors :: Src.Module -> Env.Env -> Result i w (Env.Env, Unions, Aliases)
-addCtors (Src.Module _ _ _ _ _ unions aliases _ _) env@(Env.Env home vs ts cs bs qvs qts qcs) =
+addCtors (Src.Module _ _ _ _ _ unions aliases _ _ _) env@(Env.Env home vs ts cs bs qvs qts qcs) =
   do
     unionInfo <- traverse (canonicalizeUnion env) unions
     aliasInfo <- traverse (canonicalizeAlias env) aliases

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -63,11 +63,11 @@ toEffectDups effects =
        in List.foldl' addPort Dups.none (fmap snd ports)
     Src.Manager _ manager ->
       case manager of
-        Src.Cmd (A.At region _) ->
+        Src.Cmd (A.At region _) _ ->
           Dups.one "command" region (Env.TopLevel region)
-        Src.Sub (A.At region _) ->
+        Src.Sub (A.At region _) _ ->
           Dups.one "subscription" region (Env.TopLevel region)
-        Src.Fx (A.At regionCmd _) (A.At regionSub _) ->
+        Src.Fx (A.At regionCmd _) (A.At regionSub _) _ ->
           Dups.union
             (Dups.one "command" regionCmd (Env.TopLevel regionCmd))
             (Dups.one "subscription" regionSub (Env.TopLevel regionSub))

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -120,6 +120,8 @@ canonicalize env (A.At region expression) =
         do
           fieldDict <- Dups.checkFields fields
           Can.Record <$> traverse (canonicalize env) fieldDict
+      Src.Parens _ expr _ ->
+        A.toValue <$> (canonicalize env expr)
 
 -- CANONICALIZE IF BRANCH
 

--- a/compiler/src/Canonicalize/Module.hs
+++ b/compiler/src/Canonicalize/Module.hs
@@ -35,7 +35,7 @@ type Result i w a =
 -- MODULES
 
 canonicalize :: Pkg.Name -> Map.Map ModuleName.Raw I.Interface -> Src.Module -> Result i [W.Warning] Can.Module
-canonicalize pkg ifaces modul@(Src.Module _ exports docs imports values _ _ binops effects) =
+canonicalize pkg ifaces modul@(Src.Module _ exports docs imports values _ _ binops _ effects) =
   do
     let home = ModuleName.Canonical pkg (Src.getName modul)
     let cbinops = Map.fromList (map canonicalizeBinop binops)

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Werror=incomplete-patterns #-}
 {-# OPTIONS_GHC -Wno-error=unused-matches #-}
 
 module Gren.Format (toByteStringBuilder) where
@@ -131,7 +132,6 @@ extendedGroup open baseSep sep fieldSep close base fields =
 --
 formatModule :: Src.Module -> Block
 formatModule (Src.Module moduleName exports docs imports values unions aliases binops comments effects) =
-  -- TODO: implement actual formating
   Block.stack $
     NonEmpty.fromList $
       catMaybes
@@ -558,6 +558,8 @@ formatExpr = \case
           [ Block.line $ utf8 (A.toValue name) <> Block.space <> Block.char7 '=',
             exprParensNone $ formatExpr (A.toValue expr)
           ]
+  Src.Parens comments1 expr comments2 ->
+    formatExpr $ A.toValue expr
 
 opForcesMultiline :: Name -> Bool
 opForcesMultiline op =

--- a/compiler/src/Reporting/Error/Syntax.hs
+++ b/compiler/src/Reporting/Error/Syntax.hs
@@ -70,6 +70,7 @@ data Error
   | NoPortModulesInPackage A.Region
   | NoEffectsOutsideKernel A.Region
   | ParseError Module
+  deriving (Show)
 
 -- MODULE
 
@@ -104,6 +105,7 @@ data Module
     Infix Row Col
   | --
     Declarations Decl Row Col
+  deriving (Show)
 
 data Exposing
   = ExposingSpace Space Row Col
@@ -117,6 +119,7 @@ data Exposing
   | --
     ExposingIndentEnd Row Col
   | ExposingIndentValue Row Col
+  deriving (Show)
 
 -- DECLARATIONS
 
@@ -129,6 +132,7 @@ data Decl
   | DeclDef Name.Name DeclDef Row Col
   | --
     DeclFreshLineAfterDocComment Row Col
+  deriving (Show)
 
 data DeclDef
   = DeclDefSpace Space Row Col
@@ -142,6 +146,7 @@ data DeclDef
     DeclDefIndentType Row Col
   | DeclDefIndentEquals Row Col
   | DeclDefIndentBody Row Col
+  deriving (Show)
 
 data Port
   = PortSpace Space Row Col
@@ -151,6 +156,7 @@ data Port
   | PortIndentName Row Col
   | PortIndentColon Row Col
   | PortIndentType Row Col
+  deriving (Show)
 
 -- TYPE DECLARATIONS
 
@@ -161,6 +167,7 @@ data DeclType
   | DT_Union CustomType Row Col
   | --
     DT_IndentName Row Col
+  deriving (Show)
 
 data TypeAlias
   = AliasSpace Space Row Col
@@ -170,6 +177,7 @@ data TypeAlias
   | --
     AliasIndentEquals Row Col
   | AliasIndentBody Row Col
+  deriving (Show)
 
 data CustomType
   = CT_Space Space Row Col
@@ -183,6 +191,7 @@ data CustomType
   | CT_IndentBar Row Col
   | CT_IndentAfterBar Row Col
   | CT_IndentAfterEquals Row Col
+  deriving (Show)
 
 -- EXPRESSIONS
 

--- a/compiler/src/Reporting/Render/Type/Localizer.hs
+++ b/compiler/src/Reporting/Render/Type/Localizer.hs
@@ -66,7 +66,7 @@ fromNames names =
 -- FROM MODULE
 
 fromModule :: Src.Module -> Localizer
-fromModule modul@(Src.Module _ _ _ imports _ _ _ _ _) =
+fromModule modul@(Src.Module _ _ _ imports _ _ _ _ _ _) =
   Localizer $
     Map.fromList $
       (Src.getName modul, Import Nothing All) : map toPair imports

--- a/gren.cabal
+++ b/gren.cabal
@@ -127,6 +127,7 @@ Common gren-common
         AST.Canonical
         AST.Optimized
         AST.Source
+        AST.SourceComments
         AST.Utils.Binop
         AST.Utils.Type
         Canonicalize.Effects

--- a/gren.cabal
+++ b/gren.cabal
@@ -249,8 +249,9 @@ Test-Suite gren-tests
         Helpers.Parse
 
         -- tests
-        Parse.SpaceSpec
+        Integration.FormatSpec
         Parse.RecordUpdateSpec
+        Parse.SpaceSpec
         Parse.UnderscorePatternSpec
 
     Build-Depends:

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -3,6 +3,7 @@
 module Format
   ( Flags (..),
     run,
+    formatByteString,
   )
 where
 

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Integration tests for formatting that cover both the parsing and formatting
+-- (tests go from text to text).
+module Integration.FormatSpec where
+
+import Data.ByteString.Builder qualified as Builder
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as TE
+import Data.Text.Lazy qualified as LazyText
+import Data.Text.Lazy.Encoding qualified as LTE
+import Format qualified
+import Test.Hspec
+
+spec :: Spec
+spec = do
+  describe "top-level definition" $ do
+    it "formats" $
+      ["f = {}"]
+        `shouldFormatModuleBodyAs` [ "f =",
+                                     "    {}"
+                                   ]
+  describe "expressions" $ do
+    describe "record" $ do
+      it "formats with fields" $
+        ["{a=1,   b = 2}"]
+          `shouldFormatExpressionAs` [ "{ a = 1",
+                                       ", b = 2",
+                                       "}"
+                                     ]
+
+shouldFormatModuleBodyAs :: [Text] -> [LazyText.Text] -> IO ()
+shouldFormatModuleBodyAs inputLines expectedOutputLines =
+  let input = TE.encodeUtf8 $ Text.unlines inputLines
+      expectedOutput = LazyText.unlines expectedOutputLines
+      actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString input
+   in case LazyText.stripPrefix "module Main exposing (..)\n\n\n\n" <$> actualOutput of
+        Nothing ->
+          expectationFailure "shouldFormatModuleBodyAs: failed to format"
+        Just Nothing ->
+          expectationFailure "shouldFormatModuleBodyAs: internal error: could not strip module header"
+        Just (Just actualModuleBody) ->
+          actualModuleBody `shouldBe` expectedOutput
+
+shouldFormatExpressionAs :: [Text] -> [LazyText.Text] -> IO ()
+shouldFormatExpressionAs inputLines expectedOutputLines =
+  let input = TE.encodeUtf8 $ "expr = " <> Text.unlines inputLines
+      expectedOutput = LazyText.unlines expectedOutputLines
+      actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString input
+      cleanOutput i =
+        LazyText.stripPrefix "module Main exposing (..)\n\n\n\nexpr =\n" i
+          >>= (return . LazyText.lines)
+          >>= traverse (LazyText.stripPrefix "    ")
+          >>= (return . LazyText.unlines)
+   in case fmap cleanOutput actualOutput of
+        Nothing ->
+          expectationFailure "shouldFormatExpressionAs: failed to format"
+        Just Nothing ->
+          expectationFailure "shouldFormatExpressionAs: internal error: could clean output"
+        Just (Just actualExpression) ->
+          actualExpression `shouldBe` expectedOutput

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -78,6 +78,17 @@ spec = do
                                        ", b = 2",
                                        "}"
                                      ]
+  describe "parentheses" $ do
+    it "removes unnecessary parentheses" $
+      ["(a)"]
+        `shouldFormatExpressionAs` ["a"]
+    describe "retains necessary parentheses" $ do
+      it "protects nested function application" $
+        assertFormattedExpression
+          ["f (g x)"]
+      it "retains parentheses used to group comments" $
+        assertFormattedExpression
+          ["({- A -} x)"]
 
 assertFormatted :: [Text] -> IO ()
 assertFormatted lines_ =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -17,26 +17,38 @@ spec :: Spec
 spec = do
   describe "module header" $ do
     let formattedModuleBody = "\n\n\nf =\n    {}"
-    describe "normal module" $ do
-      it "formats already formatted" $
-        assertFormatted
-          [ "module Normal exposing (..)",
+    describe "normal module" $
+      do
+        it "formats already formatted" $
+          assertFormatted
+            [ "module Normal exposing (..)",
+              formattedModuleBody
+            ]
+        it "formats" $
+          [ "module ",
+            " Normal ",
+            " exposing ",
+            " ( ",
+            " .. ",
+            " )  ",
+            "  ",
+            "",
             formattedModuleBody
           ]
-      it "formats" $
-        [ "module ",
-          " Normal ",
-          " exposing ",
-          " ( ",
-          " .. ",
-          " )  ",
-          "  ",
-          "",
-          formattedModuleBody
-        ]
-          `shouldFormatAs` [ "module Normal exposing (..)",
-                             formattedModuleBody
-                           ]
+            `shouldFormatAs` [ "module Normal exposing (..)",
+                               formattedModuleBody
+                             ]
+        it "formats with comments" $
+          [ "{-A-}",
+            "module{-B-}Normal{-C-}exposing{-D-}({-E-}..{-F-}){-G-}",
+            "{-H-}",
+            formattedModuleBody
+          ]
+            `shouldFormatAs` [ "{- A -}",
+                               "module {- B -} Normal {- C -} exposing {- D -} (..)",
+                               "{- G -} {- H -}",
+                               formattedModuleBody
+                             ]
 
   describe "top-level definition" $ do
     it "formats already formatted" $

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -45,7 +45,7 @@ shouldFormatModuleBodyAs inputLines expectedOutputLines =
 
 shouldFormatExpressionAs :: [Text] -> [LazyText.Text] -> IO ()
 shouldFormatExpressionAs inputLines expectedOutputLines =
-  let input = TE.encodeUtf8 $ "expr = " <> Text.unlines inputLines
+  let input = TE.encodeUtf8 $ "expr =\n" <> Text.unlines (fmap ("    " <>) inputLines)
       expectedOutput = LazyText.unlines expectedOutputLines
       actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString input
       cleanOutput i =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -15,6 +15,29 @@ import Test.Hspec
 
 spec :: Spec
 spec = do
+  describe "module header" $ do
+    let formattedModuleBody = "\n\n\nf =\n    {}"
+    describe "normal module" $ do
+      it "formats already formatted" $
+        assertFormatted $
+          [ "module Normal exposing (..)",
+            formattedModuleBody
+          ]
+      it "formats" $
+        [ "module ",
+          " Normal ",
+          " exposing ",
+          " ( ",
+          " .. ",
+          " )  ",
+          "  ",
+          "",
+          formattedModuleBody
+        ]
+          `shouldFormatAs` [ "module Normal exposing (..)",
+                             formattedModuleBody
+                           ]
+
   describe "top-level definition" $ do
     it "formats" $
       ["f = {}"]
@@ -29,6 +52,21 @@ spec = do
                                        ", b = 2",
                                        "}"
                                      ]
+
+assertFormatted :: [Text] -> IO ()
+assertFormatted lines_ =
+  lines_ `shouldFormatAs` lines_
+
+shouldFormatAs :: [Text] -> [Text] -> IO ()
+shouldFormatAs inputLines expectedOutputLines =
+  let input = TE.encodeUtf8 $ Text.unlines inputLines
+      expectedOutput = LazyText.fromStrict $ Text.unlines expectedOutputLines
+      actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString input
+   in case actualOutput of
+        Nothing ->
+          expectationFailure "shouldFormatAs: failed to format"
+        Just actualModuleBody ->
+          actualModuleBody `shouldBe` expectedOutput
 
 shouldFormatModuleBodyAs :: [Text] -> [LazyText.Text] -> IO ()
 shouldFormatModuleBodyAs inputLines expectedOutputLines =


### PR DESCRIPTION
This is an incremental part of the retain comments task of https://github.com/gren-lang/compiler/issues/42.  More locations of comments will be retained in future PRs (those remaining locations are being tracked by compiler warnings).

This implements comment handling in the following places:
- before the `module` line
- `module 💬 Name 💬 exposing 💬 (..) 💬`
- between `module` line and module doc comments
- between module doc comments and `import`s
- `(💬 expression)`

This also sets up a pattern for testing formatting behavior.