### PR TITLE
Keep default imports for core

### DIFF
--- a/compiler/src/Gren/Format/Normalize.hs
+++ b/compiler/src/Gren/Format/Normalize.hs
@@ -7,33 +7,39 @@
 -- as a responsibility for the code that is rendering the AST into text.
 module Gren.Format.Normalize (normalize) where
 
+import Gren.Package qualified as Pkg
 import AST.Source qualified as Src
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Name (Name)
-import Gren.Compiler.Imports qualified
+import Gren.Compiler.Imports qualified as Imports
 import Reporting.Annotation qualified as A
 import Parse.Module qualified as Parse
 
 normalize :: Parse.ProjectType -> Src.Module -> Src.Module
 normalize projectType module_ =
   module_
-    { Src._imports = mapMaybe removeDefaultImports $ Src._imports module_
+    { Src._imports = mapMaybe (removeDefaultImports projectType) $ Src._imports module_
     }
 
-removeDefaultImports :: Src.Import -> Maybe Src.Import
-removeDefaultImports import_@(Src.Import name alias exposing) =
-  case Map.lookup (A.toValue name) defaultImports of
+removeDefaultImports :: Parse.ProjectType -> Src.Import -> Maybe Src.Import
+removeDefaultImports projectType import_@(Src.Import name alias exposing) =
+  case Map.lookup (A.toValue name) (defaultImports projectType) of
     Just (Src.Import _ defAlias defExposing) ->
       if alias == defAlias && exposingEq exposing defExposing
         then Nothing
         else Just import_
     Nothing -> Just import_
 
-defaultImports :: Map Name Src.Import
-defaultImports =
-  Map.fromList $ fmap (\import_ -> (Src.getImportName import_, import_)) Gren.Compiler.Imports.defaults
+defaultImports :: Parse.ProjectType -> Map Name Src.Import
+defaultImports projectType =
+  case projectType of
+    Parse.Package pkg | pkg == Pkg.core ->
+        Map.empty
+    _ ->
+        Map.fromList $
+            fmap (\import_ -> (Src.getImportName import_, import_)) Imports.defaults
 
 exposingEq :: Src.Exposing -> Src.Exposing -> Bool
 exposingEq Src.Open Src.Open = True

--- a/compiler/src/Gren/Format/Normalize.hs
+++ b/compiler/src/Gren/Format/Normalize.hs
@@ -7,15 +7,15 @@
 -- as a responsibility for the code that is rendering the AST into text.
 module Gren.Format.Normalize (normalize) where
 
-import Gren.Package qualified as Pkg
 import AST.Source qualified as Src
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Name (Name)
 import Gren.Compiler.Imports qualified as Imports
-import Reporting.Annotation qualified as A
+import Gren.Package qualified as Pkg
 import Parse.Module qualified as Parse
+import Reporting.Annotation qualified as A
 
 normalize :: Parse.ProjectType -> Src.Module -> Src.Module
 normalize projectType module_ =
@@ -35,11 +35,12 @@ removeDefaultImports projectType import_@(Src.Import name alias exposing) =
 defaultImports :: Parse.ProjectType -> Map Name Src.Import
 defaultImports projectType =
   case projectType of
-    Parse.Package pkg | pkg == Pkg.core ->
-        Map.empty
+    Parse.Package pkg
+      | pkg == Pkg.core ->
+          Map.empty
     _ ->
-        Map.fromList $
-            fmap (\import_ -> (Src.getImportName import_, import_)) Imports.defaults
+      Map.fromList $
+        fmap (\import_ -> (Src.getImportName import_, import_)) Imports.defaults
 
 exposingEq :: Src.Exposing -> Src.Exposing -> Bool
 exposingEq Src.Open Src.Open = True

--- a/compiler/src/Gren/Format/Normalize.hs
+++ b/compiler/src/Gren/Format/Normalize.hs
@@ -14,9 +14,10 @@ import Data.Maybe (mapMaybe)
 import Data.Name (Name)
 import Gren.Compiler.Imports qualified
 import Reporting.Annotation qualified as A
+import Parse.Module qualified as Parse
 
-normalize :: Src.Module -> Src.Module
-normalize module_ =
+normalize :: Parse.ProjectType -> Src.Module -> Src.Module
+normalize projectType module_ =
   module_
     { Src._imports = mapMaybe removeDefaultImports $ Src._imports module_
     }

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -190,4 +190,4 @@ formatByteString projectType original =
       -- TODO: report error
       Nothing
     Right ast ->
-      Just (Format.toByteStringBuilder $ Normalize.normalize ast)
+      Just (Format.toByteStringBuilder $ Normalize.normalize projectType ast)


### PR DESCRIPTION
Only remove default imports if we're not formatting `gren-lang/core`.

Tagging for review: @avh4 