### PR TITLE
Report errors in gren format

### DIFF
--- a/builder/src/Gren/Outline.hs
+++ b/builder/src/Gren/Outline.hs
@@ -15,6 +15,7 @@ module Gren.Outline
     defaultSummary,
     flattenExposed,
     toAbsoluteSrcDir,
+    toGiven,
     sourceDirs,
     platform,
     dependencyConstraints,

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -2403,7 +2403,7 @@ data FormattingFailure
 
 data ValidateFailure
   = VaildateFormattingFailure FormattingFailure
-  | ValidateNotCorrectlyFormatted -- Diff
+  | ValidateNotCorrectlyFormatted
 
 formatToReport :: Format -> Help.Report
 formatToReport problem =

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -61,8 +61,10 @@ import Reporting.Doc qualified as D
 import Reporting.Error qualified as Error
 import Reporting.Error.Import qualified as Import
 import Reporting.Error.Json qualified as Json
+import Reporting.Error.Syntax qualified as Error.Syntax
 import Reporting.Exit.Help qualified as Help
 import Reporting.Render.Code qualified as Code
+import Reporting.Report qualified as Report
 import System.FilePath ((<.>), (</>))
 import System.FilePath qualified as FP
 
@@ -2392,6 +2394,7 @@ data Format
   | FormatNoOutline
   | FormatBadOutline Outline
   | FormatValidateNotCorrectlyFormatted
+  | FormatParseError BS.ByteString Error.Syntax.Error
 
 formatToReport :: Format -> Help.Report
 formatToReport problem =
@@ -2432,3 +2435,7 @@ formatToReport problem =
         Nothing
         "The input files were not correctly formatted according to Gren's preferred style."
         []
+    FormatParseError source err ->
+      Help.jsonReport (Report._title report) Nothing (Report._message report)
+      where
+        report = Error.Syntax.toReport (Code.toSource source) err

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -20,8 +20,8 @@ module Reporting.Exit
     Outdated (..),
     outdatedToReport,
     Format (..),
-    FormattingFailure(..),
-    ValidateFailure(..),
+    FormattingFailure (..),
+    ValidateFailure (..),
     formatToReport,
     newPackageOverview,
     --
@@ -41,14 +41,14 @@ module Reporting.Exit
   )
 where
 
-import Data.NonEmptyList qualified as NonEmptyList
 import Data.ByteString qualified as BS
-import Data.Maybe (mapMaybe)
 import Data.ByteString.UTF8 qualified as BS_UTF8
 import Data.List qualified as List
 import Data.Map qualified as Map
+import Data.Maybe (mapMaybe)
 import Data.Name qualified as N
 import Data.NonEmptyList qualified as NE
+import Data.NonEmptyList qualified as NonEmptyList
 import File qualified
 import Git qualified
 import Gren.Constraint qualified as C
@@ -2399,7 +2399,7 @@ data Format
   | FormatValidateErrors (NonEmptyList.List ValidateFailure)
   | FormatErrors (NonEmptyList.List FormattingFailure)
 
-data FormattingFailure 
+data FormattingFailure
   = FormattingFailureParseError (Maybe FilePath) BS.ByteString Error.Syntax.Error
 
 data ValidateFailure
@@ -2453,7 +2453,7 @@ formatToReport problem =
         (formattingErrorToDoc <$> NonEmptyList.toList errors)
 
 formattingErrorToDoc :: FormattingFailure -> D.Doc
-formattingErrorToDoc formattingError = 
+formattingErrorToDoc formattingError =
   case formattingError of
     FormattingFailureParseError path source err ->
       Help.syntaxErrorToDoc (Code.toSource source) path err

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -68,7 +68,6 @@ import Reporting.Error.Json qualified as Json
 import Reporting.Error.Syntax qualified as Error.Syntax
 import Reporting.Exit.Help qualified as Help
 import Reporting.Render.Code qualified as Code
-import Reporting.Report qualified as Report
 import System.FilePath ((<.>), (</>))
 import System.FilePath qualified as FP
 
@@ -2457,8 +2456,7 @@ formattingErrorToDoc :: FormattingFailure -> D.Doc
 formattingErrorToDoc formattingError = 
   case formattingError of
     FormattingFailureParseError path source err ->
-      let report = Error.Syntax.toReport (Code.toSource source) err
-       in Help.reportToDoc $ Help.jsonReport (Report._title report) path (Report._message report)
+      Help.syntaxErrorToDoc (Code.toSource source) path err
 
 validateErrorToDoc :: ValidateFailure -> Maybe D.Doc
 validateErrorToDoc validateError =

--- a/builder/src/Reporting/Exit.hs
+++ b/builder/src/Reporting/Exit.hs
@@ -48,7 +48,6 @@ import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Name qualified as N
 import Data.NonEmptyList qualified as NE
-import Data.NonEmptyList qualified as NonEmptyList
 import File qualified
 import Git qualified
 import Gren.Constraint qualified as C
@@ -2396,8 +2395,8 @@ data Format
   | FormatStdinWithFiles
   | FormatNoOutline
   | FormatBadOutline Outline
-  | FormatValidateErrors (NonEmptyList.List ValidateFailure)
-  | FormatErrors (NonEmptyList.List FormattingFailure)
+  | FormatValidateErrors (NE.List ValidateFailure)
+  | FormatErrors (NE.List FormattingFailure)
 
 data FormattingFailure
   = FormattingFailureParseError (Maybe FilePath) BS.ByteString Error.Syntax.Error
@@ -2444,13 +2443,13 @@ formatToReport problem =
         "FILES NOT PROPERLY FORMATTED"
         Nothing
         "The input files were not correctly formatted according to Gren's preferred style."
-        (mapMaybe validateErrorToDoc $ NonEmptyList.toList errors)
+        (mapMaybe validateErrorToDoc $ NE.toList errors)
     FormatErrors errors ->
       Help.report
         (show (length errors) <> " FILES CONTAINED ERRORS")
         Nothing
         "Some files contained errors and could not be formatted:"
-        (formattingErrorToDoc <$> NonEmptyList.toList errors)
+        (formattingErrorToDoc <$> NE.toList errors)
 
 formattingErrorToDoc :: FormattingFailure -> D.Doc
 formattingErrorToDoc formattingError =

--- a/builder/src/Reporting/Exit/Help.hs
+++ b/builder/src/Reporting/Exit/Help.hs
@@ -18,12 +18,12 @@ where
 import GHC.IO.Handle (hIsTerminalDevice)
 import Json.Encode ((==>))
 import Json.Encode qualified as E
-import Reporting.Report qualified as Report
-import Reporting.Render.Code qualified as Code
 import Reporting.Doc ((<+>))
 import Reporting.Doc qualified as D
 import Reporting.Error qualified as Error
 import Reporting.Error.Syntax qualified as Error.Syntax
+import Reporting.Render.Code qualified as Code
+import Reporting.Report qualified as Report
 import System.IO (Handle, hPutStr, stderr, stdout)
 
 -- REPORT
@@ -54,8 +54,8 @@ compilerReport =
 
 syntaxErrorToDoc :: Code.Source -> Maybe FilePath -> Error.Syntax.Error -> D.Doc
 syntaxErrorToDoc source path moduleError =
-      let syntaxReport = Error.Syntax.toReport source moduleError
-       in reportToDoc $ Report (Report._title syntaxReport) path (Report._message syntaxReport)
+  let syntaxReport = Error.Syntax.toReport source moduleError
+   in reportToDoc $ Report (Report._title syntaxReport) path (Report._message syntaxReport)
 
 -- TO DOC
 

--- a/builder/src/Reporting/Exit/Help.hs
+++ b/builder/src/Reporting/Exit/Help.hs
@@ -8,6 +8,7 @@ module Reporting.Exit.Help
     compilerReport,
     reportToDoc,
     reportToJson,
+    syntaxErrorToDoc,
     toString,
     toStdout,
     toStderr,
@@ -17,9 +18,12 @@ where
 import GHC.IO.Handle (hIsTerminalDevice)
 import Json.Encode ((==>))
 import Json.Encode qualified as E
+import Reporting.Report qualified as Report
+import Reporting.Render.Code qualified as Code
 import Reporting.Doc ((<+>))
 import Reporting.Doc qualified as D
 import Reporting.Error qualified as Error
+import Reporting.Error.Syntax qualified as Error.Syntax
 import System.IO (Handle, hPutStr, stderr, stdout)
 
 -- REPORT
@@ -47,6 +51,11 @@ jsonReport =
 compilerReport :: FilePath -> Error.Module -> [Error.Module] -> Report
 compilerReport =
   CompilerReport
+
+syntaxErrorToDoc :: Code.Source -> Maybe FilePath -> Error.Syntax.Error -> D.Doc
+syntaxErrorToDoc source path moduleError =
+      let syntaxReport = Error.Syntax.toReport source moduleError
+       in reportToDoc $ Report (Report._title syntaxReport) path (Report._message syntaxReport)
 
 -- TO DOC
 

--- a/compiler/src/Data/NonEmptyList.hs
+++ b/compiler/src/Data/NonEmptyList.hs
@@ -26,7 +26,7 @@ toList (List x xs) =
 
 fromList :: [a] -> Maybe (List a)
 fromList [] = Nothing
-fromList (x:xs) = Just (List x xs)
+fromList (x : xs) = Just (List x xs)
 
 -- INSTANCES
 

--- a/compiler/src/Data/NonEmptyList.hs
+++ b/compiler/src/Data/NonEmptyList.hs
@@ -2,6 +2,7 @@ module Data.NonEmptyList
   ( List (..),
     singleton,
     toList,
+    fromList,
     sortBy,
   )
 where
@@ -22,6 +23,10 @@ singleton a =
 toList :: List a -> [a]
 toList (List x xs) =
   x : xs
+
+fromList :: [a] -> Maybe (List a)
+fromList [] = Nothing
+fromList (x:xs) = Just (List x xs)
 
 -- INSTANCES
 

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -21,13 +21,13 @@ import Gren.Outline qualified as Outline
 import Parse.Module qualified as Parse
 import Reporting qualified
 import Reporting.Doc qualified as D
+import Reporting.Error.Syntax qualified as Syntax
 import Reporting.Exit qualified as Exit
 import Reporting.Exit.Help qualified as Help
 import Reporting.Task qualified as Task
 import System.Directory qualified as Dir
 import System.FilePath ((</>))
 import System.FilePath qualified as FilePath
-import System.IO qualified
 
 -- FLAGS
 
@@ -44,6 +44,14 @@ run paths flags = do
   let action = if _validate flags then validate else format flags
   Reporting.attempt Exit.formatToReport $
     Task.run (action =<< getEnv paths flags)
+
+-- FORMATTING RESULT
+
+data FormattingResult
+  = FormattingSuccess FormattingChange BSL.ByteString
+  | FormattingFailure BS.ByteString Syntax.Error
+
+data FormattingChange = Changed | NotChanged
 
 -- ENV
 
@@ -122,14 +130,12 @@ resolveFile path =
 format :: Flags -> Env -> Task.Task Exit.Format ()
 format flags (Env inputs) =
   case inputs of
-    Stdin ->
-      do
-        original <- Task.io BS.getContents
-        case formatByteString Parse.Application original of
-          Nothing ->
-            error "TODO: report error"
-          Just formatted ->
-            Task.io $ B.hPutBuilder System.IO.stdout formatted
+    Stdin -> do
+      formattingResult <- formatByteString Parse.Application <$> Task.io BS.getContents
+      case formattingResult of
+        FormattingFailure original e -> Task.throw (Exit.FormatParseError original e)
+        FormattingSuccess _ formatted ->
+          Task.io $ BSL.putStr formatted
     Files paths ->
       formatFilesOnDisk flags Parse.Application paths
     Project projectType paths ->
@@ -138,15 +144,8 @@ format flags (Env inputs) =
 validate :: Env -> Task.Task Exit.Format ()
 validate (Env inputs) = do
   case inputs of
-    Stdin ->
-      do
-        original <- Task.io BS.getContents
-        case formatByteString Parse.Application original of
-          Nothing ->
-            error "TODO: report error"
-          Just formatted ->
-            when (BSL.fromStrict original /= B.toLazyByteString formatted) $
-              Task.throw Exit.FormatValidateNotCorrectlyFormatted
+    Stdin -> 
+      throwWhenResultInvalid =<< formatByteString Parse.Application <$> Task.io BS.getContents
     Files paths ->
       validateFiles Parse.Application paths
     Project projectType paths ->
@@ -154,41 +153,49 @@ validate (Env inputs) = do
 
 validateFiles :: Parse.ProjectType -> [FilePath] -> Task.Task Exit.Format ()
 validateFiles projectType paths = do
-  validationResults <- mapM (validateFile projectType) paths
-  when (any (== False) validationResults) $
-    Task.throw Exit.FormatValidateNotCorrectlyFormatted
+  results <- mapM (validateFile projectType) paths
+  mapM_ throwWhenResultInvalid results
 
-validateFile :: Parse.ProjectType -> FilePath -> Task.Task Exit.Format Bool
+throwWhenResultInvalid :: FormattingResult -> Task.Task Exit.Format ()
+throwWhenResultInvalid formattingResult =
+  case formattingResult of
+    FormattingFailure original e ->
+      Task.throw (Exit.FormatParseError original e)
+    FormattingSuccess Changed _ ->
+      Task.throw Exit.FormatValidateNotCorrectlyFormatted
+    FormattingSuccess NotChanged _ ->
+      pure ()
+
+validateFile :: Parse.ProjectType -> FilePath -> Task.Task Exit.Format FormattingResult
 validateFile projectType path =
   assertFileExists path >> Task.io (validateExistingFile projectType path)
 
-validateExistingFile :: Parse.ProjectType -> FilePath -> IO Bool
+validateExistingFile :: Parse.ProjectType -> FilePath -> IO FormattingResult
 validateExistingFile projectType path = do
   putStr ("Validating " ++ path)
-  original <- File.readUtf8 path
-  case formatByteString projectType original of
-    Nothing -> do
-      -- TODO: report error
-      _ <- Help.toStdout (" " <> D.red "ERROR: could not parse file" <> "\n")
-      pure False
-    Just formatted -> do
-      let isFormatted = B.toLazyByteString formatted == BSL.fromStrict original
-          status = if isFormatted then D.green "VALID" else D.red "INVALID"
-      Help.toStdout (" " <> status <> "\n")
-      pure isFormatted
+  formattingResult <- formatByteString projectType <$> File.readUtf8 path
+  case formattingResult of
+    FormattingFailure _ _ ->
+      Help.toStdout (" " <> D.red "(parse error)" <> "\n")
+    FormattingSuccess NotChanged _ ->
+      Help.toStdout (" " <> D.green "VALID" <> "\n")
+    FormattingSuccess Changed _ -> do
+      Help.toStdout (" " <> D.red "INVALID" <> "\n")
+  pure formattingResult
 
 formatFilesOnDisk :: Flags -> Parse.ProjectType -> [FilePath] -> Task.Task Exit.Format ()
-formatFilesOnDisk flags projectType paths =
-  do
-    approved <-
-      if not (_skipPrompts flags)
-        then Task.io $ Reporting.ask (confirmFormat paths)
-        else return True
-    if approved
-      then mapM_ (formatFile projectType) paths
-      else do
-        Task.io $ putStrLn "Okay, I did not change anything!"
-        return ()
+formatFilesOnDisk flags projectType paths = do
+  approved <-
+    if not (_skipPrompts flags)
+      then Task.io $ Reporting.ask (confirmFormat paths)
+      else return True
+  if not approved
+    then Task.io $ putStrLn "Okay, I did not change anything!"
+    else do
+      formattingResults <- mapM (formatFile projectType) paths
+      case formattingResults of
+        [FormattingFailure source e] -> Task.throw (Exit.FormatParseError source e)
+        _ -> pure ()
 
 confirmFormat :: [FilePath] -> D.Doc
 confirmFormat paths =
@@ -200,36 +207,32 @@ confirmFormat paths =
         "Are you sure you want to overwrite these files with formatted versions? [Y/n]: "
     ]
 
-formatFile :: Parse.ProjectType -> FilePath -> Task.Task Exit.Format ()
+formatFile :: Parse.ProjectType -> FilePath -> Task.Task Exit.Format FormattingResult
 formatFile projectType path =
   assertFileExists path >> Task.io (formatExistingFile projectType path)
 
-formatExistingFile :: Parse.ProjectType -> FilePath -> IO ()
-formatExistingFile projectType path =
-  do
-    putStr ("Formatting " ++ path)
-    original <- File.readUtf8 path
-    case formatByteString projectType original of
-      Nothing ->
-        -- TODO: report error
-        Help.toStdout (" " <> D.red "ERROR: could not parse file" <> "\n")
-      Just builder ->
-        let formatted = B.toLazyByteString builder
-         in if formatted == BSL.fromStrict original
-              then do
-                Help.toStdout (" " <> D.dullwhite "(no changes)" <> "\n")
-              else do
-                B.writeFile path builder
-                Help.toStdout (" " <> D.green "CHANGED" <> "\n")
+formatExistingFile :: Parse.ProjectType -> FilePath -> IO FormattingResult
+formatExistingFile projectType path = do
+  putStr ("Formatting " ++ path)
+  formattingResult <- formatByteString projectType <$> File.readUtf8 path
+  case formattingResult of
+    FormattingFailure _ _ ->
+      Help.toStdout (" " <> D.red "(parse error)" <> "\n")
+    FormattingSuccess NotChanged _ ->
+      Help.toStdout (" " <> D.dullwhite "(no changes)" <> "\n")
+    FormattingSuccess Changed formatted -> do
+      BSL.writeFile path formatted
+      Help.toStdout (" " <> D.green "CHANGED" <> "\n")
+  pure formattingResult
 
-formatByteString :: Parse.ProjectType -> BS.ByteString -> Maybe B.Builder
+formatByteString :: Parse.ProjectType -> BS.ByteString -> FormattingResult
 formatByteString projectType original =
-  case Parse.fromByteString projectType original of
-    Left _ ->
-      -- TODO: report error
-      Nothing
-    Right ast ->
-      Just (Format.toByteStringBuilder $ Normalize.normalize projectType ast)
+  let formattedResult = B.toLazyByteString . Format.toByteStringBuilder . Normalize.normalize projectType <$> Parse.fromByteString projectType original
+   in case formattedResult of
+        Left e -> FormattingFailure original e
+        Right formatted
+          | formatted == BSL.fromStrict original -> FormattingSuccess NotChanged formatted
+          | otherwise -> FormattingSuccess Changed formatted
 
 assertFileExists :: FilePath -> Task.Task Exit.Format ()
 assertFileExists path = do

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -144,7 +144,7 @@ format flags (Env inputs) =
 validate :: Env -> Task.Task Exit.Format ()
 validate (Env inputs) = do
   case inputs of
-    Stdin -> 
+    Stdin ->
       throwWhenResultInvalid =<< formatByteString Parse.Application <$> Task.io BS.getContents
     Files paths ->
       validateFiles Parse.Application paths

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -14,7 +14,6 @@ import Data.ByteString.Builder qualified as B
 import Data.ByteString.Lazy qualified as BSL
 import Data.Maybe (mapMaybe)
 import Data.NonEmptyList qualified as NE
-import Data.NonEmptyList qualified as NonEmptyList
 import Directories qualified as Dirs
 import File qualified
 import Gren.Format qualified as Format
@@ -136,7 +135,7 @@ format flags (Env inputs) =
       formattingResult <- formatByteString Parse.Application Nothing <$> Task.io BS.getContents
       case formattingResult of
         FormattingFailure path source e ->
-          Task.throw $ Exit.FormatErrors (NonEmptyList.singleton $ Exit.FormattingFailureParseError path source e)
+          Task.throw $ Exit.FormatErrors (NE.singleton $ Exit.FormattingFailureParseError path source e)
         FormattingSuccess _ formatted ->
           Task.io $ BSL.putStr formatted
     Files paths ->
@@ -162,7 +161,7 @@ validateFiles projectType paths = do
 
 throwIfHasValidateErrors :: [FormattingResult] -> Task.Task Exit.Format ()
 throwIfHasValidateErrors results =
-  sequence_ $ (Task.throw . Exit.FormatValidateErrors) <$> NonEmptyList.fromList (mapMaybe validateFailure results)
+  sequence_ $ (Task.throw . Exit.FormatValidateErrors) <$> NE.fromList (mapMaybe validateFailure results)
 
 validateFailure :: FormattingResult -> Maybe Exit.ValidateFailure
 validateFailure formattingResult =
@@ -205,7 +204,7 @@ formatFilesOnDisk flags projectType paths = do
 
 throwIfHasFormattingErrors :: [FormattingResult] -> Task.Task Exit.Format ()
 throwIfHasFormattingErrors results =
-  sequence_ $ (Task.throw . Exit.FormatErrors) <$> NonEmptyList.fromList (mapMaybe formattingError results)
+  sequence_ $ (Task.throw . Exit.FormatErrors) <$> NE.fromList (mapMaybe formattingError results)
 
 formattingError :: FormattingResult -> Maybe Exit.FormattingFailure
 formattingError (FormattingFailure path source err) = Just (Exit.FormattingFailureParseError path source err)

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -7,14 +7,14 @@ module Format
   )
 where
 
-import Data.NonEmptyList qualified as NonEmptyList
 import AbsoluteSrcDir qualified
-import Data.Maybe (mapMaybe)
 import Control.Monad (filterM, when)
 import Data.ByteString qualified as BS
 import Data.ByteString.Builder qualified as B
 import Data.ByteString.Lazy qualified as BSL
+import Data.Maybe (mapMaybe)
 import Data.NonEmptyList qualified as NE
+import Data.NonEmptyList qualified as NonEmptyList
 import Directories qualified as Dirs
 import File qualified
 import Gren.Format qualified as Format
@@ -135,7 +135,7 @@ format flags (Env inputs) =
     Stdin -> do
       formattingResult <- formatByteString Parse.Application Nothing <$> Task.io BS.getContents
       case formattingResult of
-        FormattingFailure path source e -> 
+        FormattingFailure path source e ->
           Task.throw $ Exit.FormatErrors (NonEmptyList.singleton $ Exit.FormattingFailureParseError path source e)
         FormattingSuccess _ formatted ->
           Task.io $ BSL.putStr formatted
@@ -163,7 +163,6 @@ validateFiles projectType paths = do
 throwIfHasValidateErrors :: [FormattingResult] -> Task.Task Exit.Format ()
 throwIfHasValidateErrors results =
   sequence_ $ (Task.throw . Exit.FormatValidateErrors) <$> NonEmptyList.fromList (mapMaybe validateFailure results)
-
 
 validateFailure :: FormattingResult -> Maybe Exit.ValidateFailure
 validateFailure formattingResult =
@@ -207,7 +206,6 @@ formatFilesOnDisk flags projectType paths = do
 throwIfHasFormattingErrors :: [FormattingResult] -> Task.Task Exit.Format ()
 throwIfHasFormattingErrors results =
   sequence_ $ (Task.throw . Exit.FormatErrors) <$> NonEmptyList.fromList (mapMaybe formattingError results)
-
 
 formattingError :: FormattingResult -> Maybe Exit.FormattingFailure
 formattingError (FormattingFailure path source err) = Just (Exit.FormattingFailureParseError path source err)

--- a/terminal/src/Format.hs
+++ b/terminal/src/Format.hs
@@ -7,7 +7,6 @@ module Format
   )
 where
 
-import AbsoluteSrcDir qualified
 import Control.Monad (filterM, when)
 import Data.ByteString qualified as BS
 import Data.ByteString.Builder qualified as B
@@ -91,11 +90,7 @@ sourceDirsFromGrenJson =
     outline <- Task.eio Exit.FormatBadOutline $ Outline.read root
     Task.io $
       do
-        paths <-
-          filterM Dir.doesDirectoryExist
-            =<< ( traverse (fmap AbsoluteSrcDir.toFilePath <$> Outline.toAbsoluteSrcDir root) $
-                    (NE.toList (Outline.sourceDirs outline))
-                )
+        paths <- filterM Dir.doesDirectoryExist $ Outline.toGiven <$> (NE.toList $ Outline.sourceDirs outline)
         return $ case outline of
           Outline.App _ ->
             ( Parse.Application,

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -101,9 +101,9 @@ shouldFormatAs inputLines expectedOutputLines =
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
       actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString Parse.Application input
    in case actualOutput of
-        Nothing ->
+        Left _ ->
           expectationFailure "shouldFormatAs: failed to format"
-        Just actualModuleBody ->
+        Right actualModuleBody ->
           actualModuleBody `shouldBe` expectedOutput
 
 assertFormattedModuleBody :: [Text] -> IO ()
@@ -116,11 +116,11 @@ shouldFormatModuleBodyAs inputLines expectedOutputLines =
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
       actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString Parse.Application input
    in case LazyText.stripPrefix "module Main exposing (..)\n\n\n\n" <$> actualOutput of
-        Nothing ->
+        Left _ ->
           expectationFailure "shouldFormatModuleBodyAs: failed to format"
-        Just Nothing ->
+        Right Nothing ->
           expectationFailure "shouldFormatModuleBodyAs: internal error: could not strip module header"
-        Just (Just actualModuleBody) ->
+        Right (Just actualModuleBody) ->
           actualModuleBody `shouldBe` expectedOutput
 
 assertFormattedExpression :: [Text] -> IO ()
@@ -138,9 +138,9 @@ shouldFormatExpressionAs inputLines expectedOutputLines =
           >>= traverse (LazyText.stripPrefix "    ")
           >>= (return . LazyText.unlines)
    in case fmap cleanOutput actualOutput of
-        Nothing ->
+        Left _ ->
           expectationFailure "shouldFormatExpressionAs: failed to format"
-        Just Nothing ->
+        Right Nothing ->
           expectationFailure "shouldFormatExpressionAs: internal error: could clean output"
-        Just (Just actualExpression) ->
+        Right (Just actualExpression) ->
           actualExpression `shouldBe` expectedOutput


### PR DESCRIPTION
This resolves some TODOs in gren format where parse errors would lead to an impure exception.
I had to make some design decisions that I'm happy to discuss:

- If you try to format more than one file, you will get exit code 0, and no parse error message, even if all the files had parse errors.

![image](https://user-images.githubusercontent.com/25511262/194299310-1c8b0665-5c85-447f-90bc-d22ae230cc41.png)

![image](https://user-images.githubusercontent.com/25511262/194297652-b1717cc5-8ff6-4020-b669-a50558706c8a.png)

- If you format a single file that has a parse error, this will be reported.

![image](https://user-images.githubusercontent.com/25511262/194297426-3c64555c-cc6d-4cf7-93b1-eb104dc0f5ac.png)

![image](https://user-images.githubusercontent.com/25511262/194297537-f278f735-37ca-4a50-8f60-a01bc59bf1ba.png)

My reasoning is that when you format a single file you are more likely to be interested in why formatting failed, whereas when formatting a project and you might be happy knowing which files were successfully formatted.
If that made sense we might possibly also want to differentiate between formatting a project with a single file, and formatting a single file from the command line.

When validating it will currently report the first error encountered (invalid formatting or parse error):
![image](https://user-images.githubusercontent.com/25511262/194300949-d32abfe4-ffcd-4262-b3ad-e92ccf202549.png)
Should the errors be prioritized or is it unnecessary considering it will mostly be used in CI anyways? Or should validation never report the perse error (or only when used on a single file)? 🤔 
If we want to report the parse error on multiple files I need to make some changes to get the file path in the error message.