### PR TITLE
format: retain comments in expression bodies (value decls, let, lambda)

### DIFF
--- a/builder/src/Build.hs
+++ b/builder/src/Build.hs
@@ -282,7 +282,7 @@ crawlFile env@(Env _ root projectType _ _ buildID _ _) mvar docsNeed expectedNam
               else return $ SBadSyntax path time source (Syntax.ModuleNameMismatch expectedName name)
 
 isMain :: A.Located Src.Value -> Bool
-isMain (A.At _ (Src.Value (A.At _ name) _ _ _)) =
+isMain (A.At _ (Src.Value (A.At _ name) _ _ _ _)) =
   name == Name._main
 
 -- CHECK MODULE

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -64,7 +64,7 @@ data Expr_
   | Lambda [Pattern] Expr
   | Call Expr [([Comment], Expr)]
   | If [(Expr, Expr)] Expr
-  | Let [A.Located Def] Expr
+  | Let [([Comment], A.Located Def)] Expr SC.LetComments
   | Case Expr [([Comment], Pattern, Expr)]
   | Accessor Name
   | Access Expr (A.Located Name)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -78,7 +78,7 @@ data VarType = LowVar | CapVar
 -- DEFINITIONS
 
 data Def
-  = Define (A.Located Name) [Pattern] Expr (Maybe Type)
+  = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type)
   | Destruct Pattern Expr
   deriving (Show)
 
@@ -157,7 +157,7 @@ data Import = Import
   }
   deriving (Show)
 
-data Value = Value (A.Located Name) [Pattern] Expr (Maybe Type)
+data Value = Value (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type) SC.ValueComments
   deriving (Show)
 
 data Union = Union (A.Located Name) [A.Located Name] [(A.Located Name, [([Comment], Type)])]

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -61,7 +61,7 @@ data Expr_
   | Op Name
   | Negate Expr
   | Binops [(Expr, [Comment], A.Located Name)] Expr
-  | Lambda [Pattern] Expr
+  | Lambda [([Comment], Pattern)] Expr SC.LambdaComments
   | Call Expr [([Comment], Expr)]
   | If [(Expr, Expr)] Expr
   | Let [([Comment], A.Located Def)] Expr SC.LetComments

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -2,7 +2,8 @@
 {-# OPTIONS_GHC -Wall #-}
 
 module AST.Source
-  ( Comment (..),
+  ( Comment,
+    Comment_ (..),
     GREN_COMMENT,
     Expr,
     Expr_ (..),
@@ -34,7 +35,7 @@ module AST.Source
   )
 where
 
-import AST.SourceComments (Comment, GREN_COMMENT)
+import AST.SourceComments (Comment, Comment_, GREN_COMMENT)
 import AST.SourceComments qualified as SC
 import AST.Utils.Binop qualified as Binop
 import Data.List.NonEmpty (NonEmpty)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -79,7 +79,7 @@ data VarType = LowVar | CapVar
 -- DEFINITIONS
 
 data Def
-  = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type)
+  = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type) SC.ValueComments
   | Destruct Pattern Expr
   deriving (Show)
 

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -89,6 +89,12 @@ data ValueComments = ValueComments
 
 -- Expressions
 
+data LambdaComments = LambdaComments
+  { _beforeArrow :: [Comment],
+    _afterArrow :: [Comment]
+  }
+  deriving (Show)
+
 data LetComments = LetComments
   { _afterLetDecls :: [Comment],
     _afterIn :: [Comment]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -74,3 +74,11 @@ data ImportExposingComments = ImportExposingComments
     _afterExposingListing :: [Comment]
   }
   deriving (Show)
+
+-- Declarations
+
+data ValueComments = ValueComments
+  { _beforeValueEquals :: [Comment],
+    _beforeValueBody :: [Comment]
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -82,6 +82,7 @@ data ImportExposingComments = ImportExposingComments
 
 data ValueComments = ValueComments
   { _beforeValueEquals :: [Comment],
-    _beforeValueBody :: [Comment]
+    _beforeValueBody :: [Comment],
+    _afterValueBody :: [Comment]
   }
   deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -86,3 +86,11 @@ data ValueComments = ValueComments
     _afterValueBody :: [Comment]
   }
   deriving (Show)
+
+-- Expressions
+
+data LetComments = LetComments
+  { _afterLetDecls :: [Comment],
+    _afterIn :: [Comment]
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -1,10 +1,13 @@
 module AST.SourceComments where
 
 import Data.Utf8 qualified as Utf8
+import Reporting.Annotation qualified as A
 
 data GREN_COMMENT
 
-data Comment
+type Comment = A.Located Comment_
+
+data Comment_
   = BlockComment (Utf8.Utf8 GREN_COMMENT)
   | LineComment (Utf8.Utf8 GREN_COMMENT)
   deriving (Eq, Show)
@@ -67,7 +70,7 @@ data ImportAliasComments = ImportAliasComments
   { _afterAs :: [Comment],
     _afterAliasName :: [Comment]
   }
-  deriving (Eq, Show)
+  deriving (Show)
 
 data ImportExposingComments = ImportExposingComments
   { _afterExposing :: [Comment],

--- a/compiler/src/Canonicalize/Effects.hs
+++ b/compiler/src/Canonicalize/Effects.hs
@@ -113,7 +113,7 @@ verifyEffectType (A.At region name) unions =
     else Result.throw (Error.EffectNotFound region name)
 
 toNameRegion :: A.Located Src.Value -> (Name.Name, A.Region)
-toNameRegion (A.At _ (Src.Value (A.At region name) _ _ _)) =
+toNameRegion (A.At _ (Src.Value (A.At region name) _ _ _ _)) =
   (name, region)
 
 verifyManager :: A.Region -> Map.Map Name.Name A.Region -> Name.Name -> Result i w A.Region

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -47,7 +47,7 @@ addVars module_ (Env.Env home vs ts cs bs qvs qts qcs) =
 
 collectVars :: Src.Module -> Result i w (Map.Map Name.Name Env.Var)
 collectVars (Src.Module _ _ _ _ values _ _ _ _ _ effects) =
-  let addDecl dict (A.At _ (Src.Value (A.At region name) _ _ _)) =
+  let addDecl dict (A.At _ (Src.Value (A.At region name) _ _ _ _)) =
         Dups.insert name region (Env.TopLevel region) dict
    in Dups.detect Error.DuplicateDecl $
         List.foldl' addDecl (toEffectDups effects) (fmap snd values)

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -231,7 +231,7 @@ canonicalizeLet letRegion env defs body =
 addBindings :: Dups.Dict A.Region -> A.Located Src.Def -> Dups.Dict A.Region
 addBindings bindings (A.At _ def) =
   case def of
-    Src.Define (A.At region name) _ _ _ ->
+    Src.Define (A.At region name) _ _ _ _ ->
       Dups.insert name region region bindings
     Src.Destruct pattern _ ->
       addBindingsHelp bindings pattern
@@ -274,7 +274,7 @@ data Binding
 addDefNodes :: Env.Env -> [Node] -> A.Located Src.Def -> Result FreeLocals [W.Warning] [Node]
 addDefNodes env nodes (A.At _ def) =
   case def of
-    Src.Define aname@(A.At _ name) srcArgs body maybeType ->
+    Src.Define aname@(A.At _ name) srcArgs body maybeType _ ->
       case maybeType of
         Nothing ->
           do

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -98,8 +98,8 @@ canonicalize env (A.At region expression) =
         Can.If
           <$> traverse (canonicalizeIfBranch env) branches
           <*> canonicalize env finally
-      Src.Let defs expr ->
-        A.toValue <$> canonicalizeLet region env defs expr
+      Src.Let defs expr _ ->
+        A.toValue <$> canonicalizeLet region env (fmap snd defs) expr
       Src.Case expr branches ->
         Can.Case
           <$> canonicalize env expr

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -76,12 +76,12 @@ canonicalize env (A.At region expression) =
         Can.Negate <$> canonicalize env expr
       Src.Binops ops final ->
         A.toValue <$> canonicalizeBinops region env ops final
-      Src.Lambda srcArgs body ->
+      Src.Lambda srcArgs body _ ->
         delayedUsage $
           do
             (args, bindings) <-
               Pattern.verify Error.DPLambdaArgs $
-                traverse (Pattern.canonicalize env) srcArgs
+                traverse (Pattern.canonicalize env) (fmap snd srcArgs)
 
             newEnv <-
               Env.addLocals bindings env

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -280,7 +280,7 @@ addDefNodes env nodes (A.At _ def) =
           do
             (args, argBindings) <-
               Pattern.verify (Error.DPFuncArgs name) $
-                traverse (Pattern.canonicalize env) srcArgs
+                traverse (Pattern.canonicalize env . snd) srcArgs
 
             newEnv <-
               Env.addLocals argBindings env
@@ -296,7 +296,7 @@ addDefNodes env nodes (A.At _ def) =
             (Can.Forall freeVars ctipe) <- Type.toAnnotation env tipe
             ((args, resultType), argBindings) <-
               Pattern.verify (Error.DPFuncArgs name) $
-                gatherTypedArgs env name srcArgs ctipe Index.first []
+                gatherTypedArgs env name (fmap snd srcArgs) ctipe Index.first []
 
             newEnv <-
               Env.addLocals argBindings env

--- a/compiler/src/Canonicalize/Module.hs
+++ b/compiler/src/Canonicalize/Module.hs
@@ -121,13 +121,13 @@ type NodeTwo =
   (Can.Def, Name.Name, [Name.Name])
 
 toNodeOne :: Env.Env -> A.Located Src.Value -> Result i [W.Warning] NodeOne
-toNodeOne env (A.At _ (Src.Value aname@(A.At _ name) srcArgs body maybeType)) =
+toNodeOne env (A.At _ (Src.Value aname@(A.At _ name) srcArgs body maybeType _)) =
   case maybeType of
     Nothing ->
       do
         (args, argBindings) <-
           Pattern.verify (Error.DPFuncArgs name) $
-            traverse (Pattern.canonicalize env) srcArgs
+            traverse (Pattern.canonicalize env . snd) srcArgs
 
         newEnv <-
           Env.addLocals argBindings env
@@ -147,7 +147,7 @@ toNodeOne env (A.At _ (Src.Value aname@(A.At _ name) srcArgs body maybeType)) =
 
         ((args, resultType), argBindings) <-
           Pattern.verify (Error.DPFuncArgs name) $
-            Expr.gatherTypedArgs env name srcArgs tipe Index.first []
+            Expr.gatherTypedArgs env name (fmap snd srcArgs) tipe Index.first []
 
         newEnv <-
           Env.addLocals argBindings env
@@ -197,7 +197,7 @@ canonicalizeExports values unions aliases binops effects (A.At region exposing) 
         Can.Export <$> Dups.detect Error.ExportDuplicate (Dups.unions infos)
 
 valueToName :: A.Located Src.Value -> (Name.Name, ())
-valueToName (A.At _ (Src.Value (A.At _ name) _ _ _)) =
+valueToName (A.At _ (Src.Value (A.At _ name) _ _ _ _)) =
   (name, ())
 
 checkExposed ::

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -700,8 +700,8 @@ formatDef :: ([Src.Comment], A.Located Src.Def) -> Block
 formatDef (commentsBefore, def) =
   withCommentsStackBefore commentsBefore $
     case A.toValue def of
-      Src.Define name args body ann ->
-        formatBasicDef (A.toValue name) args (A.toValue body) (fmap A.toValue ann) (SC.ValueComments [] [] [])
+      Src.Define name args body ann comments ->
+        formatBasicDef (A.toValue name) args (A.toValue body) (fmap A.toValue ann) comments
       Src.Destruct pat body ->
         Block.stack
           [ spaceOrIndent

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -156,11 +156,11 @@ withCommentsStackBefore before block =
 
 formatComment :: Src.Comment -> Block
 formatComment = \case
-  Src.BlockComment text ->
+  A.At _ (Src.BlockComment text) ->
     let open = if Utf8.startsWithChar (== ' ') text then "{-" else "{- "
         close = if Utf8.endsWithWord8 0x20 {- space -} text then "-}" else " -}"
      in Block.line $ Block.string7 open <> utf8 text <> Block.string7 close
-  Src.LineComment text ->
+  A.At _ (Src.LineComment text) ->
     let open = if Utf8.startsWithChar (== ' ') text then "--" else "-- "
      in Block.mustBreak $ Block.string7 open <> utf8 text
 

--- a/compiler/src/Gren/Format/Normalize.hs
+++ b/compiler/src/Gren/Format/Normalize.hs
@@ -32,7 +32,7 @@ removeDefaultImports :: Parse.ProjectType -> ([Src.Comment], Src.Import) -> Mayb
 removeDefaultImports projectType import_@(_, Src.Import name alias exposing _ _) =
   case Map.lookup (A.toValue name) (defaultImports projectType) of
     Just (Src.Import _ defAlias defExposing _ _) ->
-      if alias == defAlias && exposingEq exposing defExposing
+      if fmap fst alias == fmap fst defAlias && exposingEq exposing defExposing
         then Nothing
         else Just import_
     Nothing -> Just import_

--- a/compiler/src/Parse/Declaration.hs
+++ b/compiler/src/Parse/Declaration.hs
@@ -14,6 +14,7 @@ where
 import AST.Source qualified as Src
 import AST.SourceComments qualified as SC
 import AST.Utils.Binop qualified as Binop
+import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.Name qualified as Name
 import Parse.Expression qualified as Expr
@@ -99,10 +100,11 @@ chompDefArgsAndBody maybeDocs start name tipe revArgs commentsBefore =
         word1 0x3D {-=-} E.DeclDefEquals
         commentsAfterEquals <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentBody
         ((body, commentsAfter), end) <- specialize E.DeclDefBody Expr.expression
-        let comments = SC.ValueComments commentsBefore commentsAfterEquals
+        let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedAtLeast 2) commentsAfter
+        let comments = SC.ValueComments commentsBefore commentsAfterEquals commentsAfterBody
         let value = Src.Value name (reverse revArgs) body tipe comments
         let avalue = A.at start end value
-        return ((Value maybeDocs avalue, commentsAfter), end)
+        return ((Value maybeDocs avalue, commentsAfterDef), end)
     ]
 
 chompMatchingName :: Name.Name -> Parser E.DeclDef (A.Located Name.Name)

--- a/compiler/src/Parse/Declaration.hs
+++ b/compiler/src/Parse/Declaration.hs
@@ -12,6 +12,7 @@ module Parse.Declaration
 where
 
 import AST.Source qualified as Src
+import AST.SourceComments qualified as SC
 import AST.Utils.Binop qualified as Binop
 import Data.List.NonEmpty (NonEmpty)
 import Data.Name qualified as Name
@@ -71,33 +72,35 @@ valueDecl maybeDocs start =
     end <- getPosition
     specialize (E.DeclDef name) $
       do
-        Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
+        commentsAfterName <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
         oneOf
           E.DeclDefEquals
           [ do
               word1 0x3A {-:-} E.DeclDefEquals
+              let commentsBeforeColon = commentsAfterName
               Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentType
               ((tipe, commentsAfterTipe), _) <- specialize E.DeclDefType Type.expression
               Space.checkFreshLine E.DeclDefNameRepeat
               defName <- chompMatchingName name
-              Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
-              chompDefArgsAndBody maybeDocs start defName (Just tipe) [],
-            chompDefArgsAndBody maybeDocs start (A.at start end name) Nothing []
+              commentsAfterMatchingName <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
+              chompDefArgsAndBody maybeDocs start defName (Just tipe) [] commentsAfterMatchingName,
+            chompDefArgsAndBody maybeDocs start (A.at start end name) Nothing [] commentsAfterName
           ]
 
-chompDefArgsAndBody :: Maybe Src.DocComment -> A.Position -> A.Located Name.Name -> Maybe Src.Type -> [Src.Pattern] -> Space.Parser E.DeclDef (Decl, [Src.Comment])
-chompDefArgsAndBody maybeDocs start name tipe revArgs =
+chompDefArgsAndBody :: Maybe Src.DocComment -> A.Position -> A.Located Name.Name -> Maybe Src.Type -> [([Src.Comment], Src.Pattern)] -> [Src.Comment] -> Space.Parser E.DeclDef (Decl, [Src.Comment])
+chompDefArgsAndBody maybeDocs start name tipe revArgs commentsBefore =
   oneOf
     E.DeclDefEquals
     [ do
         arg <- specialize E.DeclDefArg Pattern.term
-        Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
-        chompDefArgsAndBody maybeDocs start name tipe (arg : revArgs),
+        commentsAfterArg <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
+        chompDefArgsAndBody maybeDocs start name tipe ((commentsBefore, arg) : revArgs) commentsAfterArg,
       do
         word1 0x3D {-=-} E.DeclDefEquals
-        Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentBody
+        commentsAfterEquals <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentBody
         ((body, commentsAfter), end) <- specialize E.DeclDefBody Expr.expression
-        let value = Src.Value name (reverse revArgs) body tipe
+        let comments = SC.ValueComments commentsBefore commentsAfterEquals
+        let value = Src.Value name (reverse revArgs) body tipe comments
         let avalue = A.at start end value
         return ((Value maybeDocs avalue, commentsAfter), end)
     ]

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -399,7 +399,7 @@ chompImport =
     Keyword.import_ E.ImportStart
     commentsAfterImportKeyword <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentName
     name@(A.At (A.Region _ end) _) <- addLocation (Var.moduleName E.ImportName)
-    commentsAfterName <- Space.chompIndentedAtLeast 1 E.ModuleSpace
+    commentsAfterName <- Space.chompIndentedAtLeast 2 E.ModuleSpace
     outdentedComments <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
@@ -424,7 +424,7 @@ chompAs name comments =
     commentsAfterAs <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentAlias
     alias <- Var.moduleName E.ImportAlias
     end <- getPosition
-    commentsAfterAliasName <- Space.chompIndentedAtLeast 1 E.ModuleSpace
+    commentsAfterAliasName <- Space.chompIndentedAtLeast 2 E.ModuleSpace
     outdentedComments <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
@@ -444,7 +444,7 @@ chompExposing name maybeAlias comments =
     Keyword.exposing_ E.ImportExposing
     commentsAfterExposing <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentExposingArray
     exposed <- specialize E.ImportExposingArray exposing
-    commentsAfterListing <- Space.chompIndentedAtLeast 1 E.ModuleSpace
+    commentsAfterListing <- Space.chompIndentedAtLeast 2 E.ModuleSpace
     outdentedComments <- freshLine E.ImportEnd
     let exposingComments = SC.ImportExposingComments commentsAfterExposing commentsAfterListing
     return (Src.Import name maybeAlias exposed (Just exposingComments) comments, outdentedComments)

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -165,7 +165,7 @@ getDocComments decls comments =
       comments
     decl : otherDecls ->
       case decl of
-        Decl.Value c (A.At _ (Src.Value n _ _ _)) -> getDocComments otherDecls (addComment c n comments)
+        Decl.Value c (A.At _ (Src.Value n _ _ _ _)) -> getDocComments otherDecls (addComment c n comments)
         Decl.Union c (A.At _ (Src.Union n _ _)) -> getDocComments otherDecls (addComment c n comments)
         Decl.Alias c (A.At _ (Src.Alias n _ _)) -> getDocComments otherDecls (addComment c n comments)
         Decl.Port c (Src.Port n _) -> getDocComments otherDecls (addComment c n comments)

--- a/compiler/src/Parse/Space.hs
+++ b/compiler/src/Parse/Space.hs
@@ -36,7 +36,7 @@ type Parser x a =
 
 chomp :: (E.Space -> Row -> Col -> x) -> P.Parser x [Src.Comment]
 chomp =
-  chompIndentedAtLeast 0
+  chompIndentedAtLeast 1
 
 chompIndentedAtLeast :: Col -> (E.Space -> Row -> Col -> x) -> P.Parser x [Src.Comment]
 chompIndentedAtLeast requiredIndent toError =
@@ -105,12 +105,12 @@ eatSpacesIndentedAtLeast indent pos end row col comments =
       0x0A {- \n -} ->
         eatSpacesIndentedAtLeast indent (plusPtr pos 1) end (row + 1) 1 comments
       0x7B {- { -} ->
-        if col > indent
+        if col >= indent
           then eatMultiComment indent pos end row col comments
           else (# Good (reverse comments), pos, row, col #)
       0x2D {- - -} ->
         let !pos1 = plusPtr pos 1
-         in if pos1 < end && col > indent && P.unsafeIndex pos1 == 0x2D {- - -}
+         in if pos1 < end && col >= indent && P.unsafeIndex pos1 == 0x2D {- - -}
               then
                 let !start = plusPtr pos 2
                  in eatLineComment indent start start end row col (col + 2) comments

--- a/compiler/src/Reporting/Annotation.hs
+++ b/compiler/src/Reporting/Annotation.hs
@@ -8,6 +8,7 @@ module Reporting.Annotation
     toValue,
     merge,
     at,
+    isIndentedAtLeast,
     toRegion,
     mergeRegions,
     zero,
@@ -41,6 +42,10 @@ toValue (At _ value) =
 merge :: Located a -> Located b -> value -> Located value
 merge (At r1 _) (At r2 _) value =
   At (mergeRegions r1 r2) value
+
+isIndentedAtLeast :: Word16 -> Located a -> Bool
+isIndentedAtLeast indent (At (Region (Position _ col) _) _) =
+  col >= indent
 
 -- POSITION
 

--- a/terminal/src/Repl.hs
+++ b/terminal/src/Repl.hs
@@ -282,7 +282,7 @@ attemptDeclOrExpr lines =
    in case P.fromByteString declParser (,) src of
         Right ((decl, _), _) ->
           case decl of
-            PD.Value _ (A.At _ (Src.Value (A.At _ name) _ _ _)) -> ifDone lines (Decl name src)
+            PD.Value _ (A.At _ (Src.Value (A.At _ name) _ _ _ _)) -> ifDone lines (Decl name src)
             PD.Union _ (A.At _ (Src.Union (A.At _ name) _ _)) -> ifDone lines (Type name src)
             PD.Alias _ (A.At _ (Src.Alias (A.At _ name) _ _)) -> ifDone lines (Type name src)
             PD.Port _ _ -> Done Port

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -291,6 +291,11 @@ spec = do
                                      ]
 
   describe "expressions" $ do
+    describe "lambda" $ do
+      it "formats comments" $
+        ["\\{-A-}x{-B-}y{-C-}->{-D-}[]"]
+          `shouldFormatExpressionAs` ["\\{- A -} x {- B -} y {- C -} -> {- D -} []"]
+
     describe "let" $ do
       it "formats comments" $
         ["let{-A-}x=1{-B-}in{-C-}x"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -298,23 +298,25 @@ spec = do
 
     describe "let" $ do
       it "formats comments" $
-        ["let{-A-}x=1{-B-}in{-C-}x"]
+        ["let{-A-}x{-D-}={-E-}1{-B-}in{-C-}x"]
           `shouldFormatExpressionAs` [ "let",
                                        "    {- A -}",
-                                       "    x =",
+                                       "    x {- D -} =",
+                                       "        {- E -}",
                                        "        1",
-                                       "",
-                                       "    {- B -}",
+                                       "        {- B -}",
                                        "in",
                                        "{- C -}",
                                        "x"
                                      ]
-      it "formats comments between declarations" $
+      it "formats comments between and after declarations" $
         [ "let",
           "    x = 1",
           "    {-A-}",
           "{-B-}",
           "    y = 2",
+          "    {-C-}",
+          "{-D-}",
           "in x"
         ]
           `shouldFormatExpressionAs` [ "let",
@@ -324,6 +326,21 @@ spec = do
                                        "    {- A -} {- B -}",
                                        "    y =",
                                        "        2",
+                                       "",
+                                       "    {- C -} {- D -}",
+                                       "in",
+                                       "x"
+                                     ]
+      it "formats indented comments after declarations" $
+        [ "let",
+          "    x = 1",
+          "     {-A-}",
+          "in x"
+        ]
+          `shouldFormatExpressionAs` [ "let",
+                                       "    x =",
+                                       "        1",
+                                       "        {- A -}",
                                        "in",
                                        "x"
                                      ]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -363,12 +363,17 @@ shouldFormatExpressionAs inputLines expectedOutputLines =
       cleanOutput i =
         LazyText.stripPrefix "module Main exposing (..)\n\n\n\nexpr =\n" i
           >>= (return . LazyText.lines)
-          >>= traverse (LazyText.stripPrefix "    ")
+          >>= traverse stripIndent
           >>= (return . LazyText.unlines)
    in case fmap cleanOutput actualOutput of
-        Left _ ->
-          expectationFailure "shouldFormatExpressionAs: failed to format"
+        Left err ->
+          expectationFailure ("shouldFormatExpressionAs: failed to format: " <> show err)
         Right Nothing ->
-          expectationFailure "shouldFormatExpressionAs: internal error: could clean output"
+          expectationFailure ("shouldFormatExpressionAs: internal error: couldn't clean output: " <> show actualOutput)
         Right (Just actualExpression) ->
           actualExpression `shouldBe` expectedOutput
+  where
+    stripIndent text =
+      if text == ""
+        then Just text
+        else LazyText.stripPrefix "    " text

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -281,6 +281,14 @@ spec = do
                                        "    {- D -}",
                                        "    []"
                                      ]
+      it "formats indented comments after the body" $ do
+        [ "f = []",
+          " {-B-}"
+          ]
+          `shouldFormatModuleBodyAs` [ "f =",
+                                       "    []",
+                                       "    {- B -}"
+                                     ]
 
   describe "expressions" $ do
     describe "record" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -274,6 +274,14 @@ spec = do
                                      "    {}"
                                    ]
 
+    describe "value declarations" $ do
+      it "formats comments" $
+        ["f{-A-}x{-B-}y{-C-}={-D-}[]"]
+          `shouldFormatModuleBodyAs` [ "f {- A -} x {- B -} y {- C -} =",
+                                       "    {- D -}",
+                                       "    []"
+                                     ]
+
   describe "expressions" $ do
     describe "record" $ do
       describe "empty" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -309,6 +309,24 @@ spec = do
                                        "{- C -}",
                                        "x"
                                      ]
+      it "formats comments between declarations" $
+        [ "let",
+          "    x = 1",
+          "    {-A-}",
+          "{-B-}",
+          "    y = 2",
+          "in x"
+        ]
+          `shouldFormatExpressionAs` [ "let",
+                                       "    x =",
+                                       "        1",
+                                       "",
+                                       "    {- A -} {- B -}",
+                                       "    y =",
+                                       "        2",
+                                       "in",
+                                       "x"
+                                     ]
 
     describe "record" $ do
       describe "empty" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -291,6 +291,20 @@ spec = do
                                      ]
 
   describe "expressions" $ do
+    describe "let" $ do
+      it "formats comments" $
+        ["let{-A-}x=1{-B-}in{-C-}x"]
+          `shouldFormatExpressionAs` [ "let",
+                                       "    {- A -}",
+                                       "    x =",
+                                       "        1",
+                                       "",
+                                       "    {- B -}",
+                                       "in",
+                                       "{- C -}",
+                                       "x"
+                                     ]
+
     describe "record" $ do
       describe "empty" $ do
         it "formats already formatted" $
@@ -307,6 +321,7 @@ spec = do
                                        ", b = 2",
                                        "}"
                                      ]
+
   describe "parentheses" $ do
     it "removes unnecessary parentheses" $
       ["(a)"]

--- a/tests/Parse/SpaceSpec.hs
+++ b/tests/Parse/SpaceSpec.hs
@@ -2,11 +2,13 @@
 
 module Parse.SpaceSpec where
 
-import AST.Source (Comment (..))
+import AST.Source (Comment, Comment_ (..))
 import Data.ByteString qualified as BS
+import Data.Word (Word16)
 import Helpers.Instances ()
 import Parse.Primitives qualified as P
 import Parse.Space qualified as Space
+import Reporting.Annotation qualified as A
 import Test.Hspec
 
 data ParseError x
@@ -25,50 +27,59 @@ spec = do
           return result
 
     it "parses spaces and newlines" $
-      parseChomp "  \n  " `shouldBe` Right []
+      parseChomp "  \n  " `shouldParseComments` Right []
 
     it "parses tokens before and after" $
-      parseChomp3 a b "a b" `shouldBe` Right []
+      parseChomp3 a b "a b" `shouldParseComments` Right []
 
     it "allows zero whitespace" $
-      parseChomp3 a b "ab" `shouldBe` Right []
+      parseChomp3 a b "ab" `shouldParseComments` Right []
 
     it "parses curly brace comments" $
-      parseChomp "{- 1 -}" `shouldBe` Right [BlockComment " 1 "]
+      parseChomp "{- 1 -}"
+        `shouldParseComments` Right [at 1 1 1 8 $ BlockComment " 1 "]
 
     it "can parse curly brace token adjacent to whitespace" $
       parseChomp3 leftCurly leftCurly "{{- 1 -} {"
-        `shouldBe` Right [BlockComment " 1 "]
+        `shouldParseComments` Right [at 1 2 1 9 $ BlockComment " 1 "]
 
     it "can parse nested curly brace comments" $
       parseChomp "{- {- inner -} outer -}"
-        `shouldBe` Right [BlockComment " {- inner -} outer "]
+        `shouldParseComments` Right [at 1 1 1 24 $ BlockComment " {- inner -} outer "]
 
     it "parses hyphen comments" $
-      parseChomp "-- 1\n" `shouldBe` Right [LineComment " 1"]
+      parseChomp "-- 1\n" `shouldParseComments` Right [at 1 1 1 5 $ LineComment " 1"]
 
     it "parses hyphen comments at end of file" $
-      parseChomp "-- 1" `shouldBe` Right [LineComment " 1"]
+      parseChomp "-- 1" `shouldParseComments` Right [at 1 1 1 5 $ LineComment " 1"]
 
     it "can parse hyphen adjacent to whitespace" $
-      parseChomp3 hyphen hyphen "- -- 1\n-" `shouldBe` Right [LineComment " 1"]
+      parseChomp3 hyphen hyphen "- -- 1\n-" `shouldParseComments` Right [at 1 3 1 7 $ LineComment " 1"]
 
     it "can parse nested hyphen comments" $
-      parseChomp "-- outer -- inner" `shouldBe` Right [LineComment " outer -- inner"]
+      parseChomp "-- outer -- inner" `shouldParseComments` Right [at 1 1 1 18 $ LineComment " outer -- inner"]
 
     it "returns comments in the correct order" $
       parseChomp "{- 1 -}{- 2 -}  -- 3\n{- 4 -}\n{- 5 -}"
-        `shouldBe` Right
-          [ BlockComment " 1 ",
-            BlockComment " 2 ",
-            LineComment " 3",
-            BlockComment " 4 ",
-            BlockComment " 5 "
+        `shouldParseComments` Right
+          [ at 1 1 1 8 $ BlockComment " 1 ",
+            at 1 8 1 15 $ BlockComment " 2 ",
+            at 1 17 1 21 $ LineComment " 3",
+            at 2 1 2 8 $ BlockComment " 4 ",
+            at 3 1 3 8 $ BlockComment " 5 "
           ]
 
 parse :: P.Parser (ParseError x) a -> BS.ByteString -> Either (ParseError x) a
 parse parser =
   P.fromByteString parser (OtherError "fromByteString failed")
+
+shouldParseComments :: (Eq x, Show x) => Either x [Comment] -> Either x [Comment] -> IO ()
+shouldParseComments actual expected =
+  fmap (fmap locatedToTuple) actual
+    `shouldBe` fmap (fmap locatedToTuple) expected
+  where
+    locatedToTuple (A.At (A.Region start end) comment) =
+      ((start, end), comment)
 
 a :: P.Parser (ParseError x) ()
 a = P.word1 0x61 {- a -} (OtherError "Expected 'a'")
@@ -81,3 +92,7 @@ leftCurly = P.word1 0x7B {- { -} (OtherError "Expected '{'")
 
 hyphen :: P.Parser (ParseError x) ()
 hyphen = P.word1 0x2D {- - -} (OtherError "Expected '-'")
+
+at :: Word16 -> Word16 -> Word16 -> Word16 -> a -> A.Located a
+at startRow startCol endRow endCol =
+  A.At (A.Region (A.Position startRow startCol) (A.Position endRow endCol))


### PR DESCRIPTION
After this PR, https://github.com/gren-lang/example-projects can now be safely formatted! (At least the `main` branch; I'll check `0.2` branch next)

- retain comments within top-level value declarations...
  - [x] before each argument pattern
  - [x] before `=`
  - [x] between `=` and the body
  - [x] after the body (indented, before the next freshline)
- retain comments within `let` expressions...
  - [x] between `let` keyword and first declaration
  - [x] between declarations
  - [x] after declaration bodies (indented)
  - [x] between last declaration and `in` keyword
  - [x] between `in` keyword and body
- retain comments within lambda expressions...
  - [x] between `\` and first arg
  - [x] between args
  - [x] between last arg and `->`
  - [x] between `->` and body
