### PR TITLE
Fix regression where truncate and remainderBy wasn't inlined

### DIFF
--- a/compiler/src/Data/Name.hs
+++ b/compiler/src/Data/Name.hs
@@ -50,6 +50,7 @@ module Data.Name
     debugger,
     bitwise,
     basics,
+    math,
     utils,
     negate,
     true,
@@ -435,6 +436,9 @@ bitwise = fromChars "Bitwise"
 
 basics :: Name
 basics = fromChars "Basics"
+
+math :: Name
+math = fromChars "Math"
 
 utils :: Name
 utils = fromChars "Utils"


### PR DESCRIPTION
This optimization is sensitive to the namespace of those two functions, which moved to a `Math` module in Gren 0.1.