### PR TITLE
format: retain comments in `case` and `if` expressions

### DIFF
--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -8,6 +8,7 @@ module AST.Source
     Expr,
     Expr_ (..),
     VarType (..),
+    CaseBranch,
     Def (..),
     Pattern,
     Pattern_ (..),
@@ -65,7 +66,7 @@ data Expr_
   | Call Expr [([Comment], Expr)]
   | If [(Expr, Expr)] Expr
   | Let [([Comment], A.Located Def)] Expr SC.LetComments
-  | Case Expr [([Comment], Pattern, Expr)]
+  | Case Expr [CaseBranch] SC.CaseComments
   | Accessor Name
   | Access Expr (A.Located Name)
   | Update Expr [(A.Located Name, Expr)]
@@ -75,6 +76,9 @@ data Expr_
 
 data VarType = LowVar | CapVar
   deriving (Show)
+
+type CaseBranch =
+  (Pattern, Expr, SC.CaseBranchComments)
 
 -- DEFINITIONS
 
@@ -92,8 +96,8 @@ data Pattern_
   | PVar Name
   | PRecord [RecordFieldPattern]
   | PAlias Pattern (A.Located Name)
-  | PCtor A.Region Name [Pattern]
-  | PCtorQual A.Region Name Name [Pattern]
+  | PCtor A.Region Name [([Comment], Pattern)]
+  | PCtorQual A.Region Name Name [([Comment], Pattern)]
   | PArray [Pattern]
   | PChr ES.String
   | PStr ES.String

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -8,6 +8,7 @@ module AST.Source
     Expr,
     Expr_ (..),
     VarType (..),
+    IfBranch,
     CaseBranch,
     Def (..),
     Pattern,
@@ -64,7 +65,7 @@ data Expr_
   | Binops [(Expr, [Comment], A.Located Name)] Expr
   | Lambda [([Comment], Pattern)] Expr SC.LambdaComments
   | Call Expr [([Comment], Expr)]
-  | If [(Expr, Expr)] Expr
+  | If [IfBranch] Expr SC.IfComments
   | Let [([Comment], A.Located Def)] Expr SC.LetComments
   | Case Expr [CaseBranch] SC.CaseComments
   | Accessor Name
@@ -76,6 +77,9 @@ data Expr_
 
 data VarType = LowVar | CapVar
   deriving (Show)
+
+type IfBranch =
+  (Expr, Expr, SC.IfBranchComments)
 
 type CaseBranch =
   (Pattern, Expr, SC.CaseBranchComments)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -95,6 +95,20 @@ data LambdaComments = LambdaComments
   }
   deriving (Show)
 
+data IfComments = IfComments
+  { _beforeElseBody :: [Comment],
+    _afterElseBody :: [Comment]
+  }
+  deriving (Show)
+
+data IfBranchComments = IfBranchComments
+  { _afterIfKeyword :: [Comment],
+    _beforeThenKeyword :: [Comment],
+    _beforeThenBody :: [Comment],
+    _afterThenBody :: [Comment]
+  }
+  deriving (Show)
+
 data LetComments = LetComments
   { _afterLetDecls :: [Comment],
     _afterIn :: [Comment]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -100,3 +100,16 @@ data LetComments = LetComments
     _afterIn :: [Comment]
   }
   deriving (Show)
+
+data CaseComments = CaseComments
+  { _afterCaseKeyword :: [Comment],
+    _beforeOfKeyword :: [Comment]
+  }
+  deriving (Show)
+
+data CaseBranchComments = CaseBranchComments
+  { _beforeBranch :: [Comment],
+    _beforeBranchArrow :: [Comment],
+    _beforeBranchBody :: [Comment]
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -110,6 +110,7 @@ data CaseComments = CaseComments
 data CaseBranchComments = CaseBranchComments
   { _beforeBranch :: [Comment],
     _beforeBranchArrow :: [Comment],
-    _beforeBranchBody :: [Comment]
+    _beforeBranchBody :: [Comment],
+    _afterBranchBody :: [Comment]
   }
   deriving (Show)

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -94,7 +94,7 @@ canonicalize env (A.At region expression) =
         Can.Call
           <$> canonicalize env func
           <*> traverse (canonicalize env) (fmap snd args)
-      Src.If branches finally ->
+      Src.If branches finally _ ->
         Can.If
           <$> traverse (canonicalizeIfBranch env) branches
           <*> canonicalize env finally
@@ -125,8 +125,8 @@ canonicalize env (A.At region expression) =
 
 -- CANONICALIZE IF BRANCH
 
-canonicalizeIfBranch :: Env.Env -> (Src.Expr, Src.Expr) -> Result FreeLocals [W.Warning] (Can.Expr, Can.Expr)
-canonicalizeIfBranch env (condition, branch) =
+canonicalizeIfBranch :: Env.Env -> Src.IfBranch -> Result FreeLocals [W.Warning] (Can.Expr, Can.Expr)
+canonicalizeIfBranch env (condition, branch, _) =
   (,)
     <$> canonicalize env condition
     <*> canonicalize env branch

--- a/compiler/src/Canonicalize/Pattern.hs
+++ b/compiler/src/Canonicalize/Pattern.hs
@@ -65,9 +65,9 @@ canonicalize env (A.At region pattern) =
       Src.PRecord fields ->
         Can.PRecord <$> canonicalizeRecordFields env fields
       Src.PCtor nameRegion name patterns ->
-        canonicalizeCtor env region name patterns =<< Env.findCtor nameRegion env name
+        canonicalizeCtor env region name (fmap snd patterns) =<< Env.findCtor nameRegion env name
       Src.PCtorQual nameRegion home name patterns ->
-        canonicalizeCtor env region name patterns =<< Env.findCtorQual nameRegion env home name
+        canonicalizeCtor env region name (fmap snd patterns) =<< Env.findCtorQual nameRegion env home name
       Src.PArray patterns ->
         Can.PArray <$> canonicalizeList env patterns
       Src.PAlias ptrn (A.At reg name) ->

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -638,7 +638,7 @@ formatExpr = \case
           ]
           :| List.intersperse Block.blankLine (fmap (Block.indent . formatCaseBranch) branches)
     where
-      formatCaseBranch (pat, expr, SC.CaseBranchComments commentsBefore commentsAfterPattern commentsBeforeBody) =
+      formatCaseBranch (pat, expr, SC.CaseBranchComments commentsBefore commentsAfterPattern commentsBeforeBody commentsAfterBody) =
         withCommentsStackBefore commentsBefore $
           Block.stack
             [ spaceOrStack
@@ -648,7 +648,7 @@ formatExpr = \case
                   Block.line $ Block.string7 "->"
                 ],
               Block.indent $
-                withCommentsStackBefore commentsBeforeBody $
+                withCommentsStackAround commentsBeforeBody commentsAfterBody $
                   exprParensNone $
                     formatExpr $
                       A.toValue expr

--- a/compiler/src/Parse/Declaration.hs
+++ b/compiler/src/Parse/Declaration.hs
@@ -100,7 +100,7 @@ chompDefArgsAndBody maybeDocs start name tipe revArgs commentsBefore =
         word1 0x3D {-=-} E.DeclDefEquals
         commentsAfterEquals <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentBody
         ((body, commentsAfter), end) <- specialize E.DeclDefBody Expr.expression
-        let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedAtLeast 2) commentsAfter
+        let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedMoreThan 1) commentsAfter
         let comments = SC.ValueComments commentsBefore commentsAfterEquals commentsAfterBody
         let value = Src.Value name (reverse revArgs) body tipe comments
         let avalue = A.at start end value

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -431,12 +431,14 @@ case_ start =
 chompBranch :: [Src.Comment] -> Space.Parser E.Case (Src.CaseBranch, [Src.Comment])
 chompBranch commentsBeforeBranch =
   do
+    indent <- getCol
     ((pattern, commentsAfterPattern), patternEnd) <- specialize E.CasePattern Pattern.expression
     Space.checkIndent patternEnd E.CaseIndentArrow
     word2 0x2D 0x3E {-->-} E.CaseArrow
     commentsAfterArrow <- Space.chompAndCheckIndent E.CaseSpace E.CaseIndentBranch
-    ((branchExpr, commentsAfterBranch), end) <- specialize E.CaseBranch expression
-    let branchComments = SC.CaseBranchComments commentsBeforeBranch commentsAfterPattern commentsAfterArrow
+    ((branchExpr, commentsAfterBranchExpr), end) <- specialize E.CaseBranch expression
+    let (commentsAfterBranchBody, commentsAfterBranch) = List.span (A.isIndentedAtLeast (indent + 1)) commentsAfterBranchExpr
+    let branchComments = SC.CaseBranchComments commentsBeforeBranch commentsAfterPattern commentsAfterArrow commentsAfterBranchBody
     let branch = (pattern, branchExpr, branchComments)
     return ((branch, commentsAfterBranch), end)
 

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -437,7 +437,7 @@ chompBranch commentsBeforeBranch =
     word2 0x2D 0x3E {-->-} E.CaseArrow
     commentsAfterArrow <- Space.chompAndCheckIndent E.CaseSpace E.CaseIndentBranch
     ((branchExpr, commentsAfterBranchExpr), end) <- specialize E.CaseBranch expression
-    let (commentsAfterBranchBody, commentsAfterBranch) = List.span (A.isIndentedAtLeast (indent + 1)) commentsAfterBranchExpr
+    let (commentsAfterBranchBody, commentsAfterBranch) = List.span (A.isIndentedMoreThan indent) commentsAfterBranchExpr
     let branchComments = SC.CaseBranchComments commentsBeforeBranch commentsAfterPattern commentsAfterArrow commentsAfterBranchBody
     let branch = (pattern, branchExpr, branchComments)
     return ((branch, commentsAfterBranch), end)
@@ -532,7 +532,7 @@ chompDefArgsAndBody start@(A.Position _ startCol) name tipe revArgs commentsBefo
         word1 0x3D {-=-} E.DefEquals
         commentsAfterEquals <- Space.chompAndCheckIndent E.DefSpace E.DefIndentBody
         ((body, commentsAfter), end) <- specialize E.DefBody expression
-        let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedAtLeast (startCol + 1)) commentsAfter
+        let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedMoreThan startCol) commentsAfter
         let comments = SC.ValueComments commentsBefore commentsAfterEquals commentsAfterBody
         return
           ( (A.at start end (Src.Define name (reverse revArgs) body tipe comments), commentsAfterDef),

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -399,7 +399,7 @@ chompImport =
     Keyword.import_ E.ImportStart
     commentsAfterImportKeyword <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentName
     name@(A.At (A.Region _ end) _) <- addLocation (Var.moduleName E.ImportName)
-    commentsAfterName <- Space.chompIndentedAtLeast 2 E.ModuleSpace
+    commentsAfterName <- Space.chompIndentedMoreThan 1 E.ModuleSpace
     outdentedComments <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
@@ -424,7 +424,7 @@ chompAs name comments =
     commentsAfterAs <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentAlias
     alias <- Var.moduleName E.ImportAlias
     end <- getPosition
-    commentsAfterAliasName <- Space.chompIndentedAtLeast 2 E.ModuleSpace
+    commentsAfterAliasName <- Space.chompIndentedMoreThan 1 E.ModuleSpace
     outdentedComments <- Space.chomp E.ModuleSpace
     oneOf
       E.ImportEnd
@@ -444,7 +444,7 @@ chompExposing name maybeAlias comments =
     Keyword.exposing_ E.ImportExposing
     commentsAfterExposing <- Space.chompAndCheckIndent E.ModuleSpace E.ImportIndentExposingArray
     exposed <- specialize E.ImportExposingArray exposing
-    commentsAfterListing <- Space.chompIndentedAtLeast 2 E.ModuleSpace
+    commentsAfterListing <- Space.chompIndentedMoreThan 1 E.ModuleSpace
     outdentedComments <- freshLine E.ImportEnd
     let exposingComments = SC.ImportExposingComments commentsAfterExposing commentsAfterListing
     return (Src.Import name maybeAlias exposed (Just exposingComments) comments, outdentedComments)

--- a/compiler/src/Reporting/Annotation.hs
+++ b/compiler/src/Reporting/Annotation.hs
@@ -8,7 +8,7 @@ module Reporting.Annotation
     toValue,
     merge,
     at,
-    isIndentedAtLeast,
+    isIndentedMoreThan,
     toRegion,
     mergeRegions,
     zero,
@@ -43,9 +43,9 @@ merge :: Located a -> Located b -> value -> Located value
 merge (At r1 _) (At r2 _) value =
   At (mergeRegions r1 r2) value
 
-isIndentedAtLeast :: Word16 -> Located a -> Bool
-isIndentedAtLeast indent (At (Region (Position _ col) _) _) =
-  col >= indent
+isIndentedMoreThan :: Word16 -> Located a -> Bool
+isIndentedMoreThan indent (At (Region (Position _ col) _) _) =
+  col > indent
 
 -- POSITION
 

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -296,6 +296,33 @@ spec = do
         ["\\{-A-}x{-B-}y{-C-}->{-D-}[]"]
           `shouldFormatExpressionAs` ["\\{- A -} x {- B -} y {- C -} -> {- D -} []"]
 
+    describe "if" $ do
+      it "formats comments" $
+        ["if{-A-}x{-B-}then{-C-}1{-D-}else{-E-}if{-F-}y{-G-}then{-H-}2{-I-}else{-J-}3"]
+          `shouldFormatExpressionAs` [ "if {- A -} x {- B -} then",
+                                       "    {- C -}",
+                                       "    1",
+                                       "    {- D -}",
+                                       "else if {- E -} {- F -} y {- G -} then",
+                                       "    {- H -}",
+                                       "    2",
+                                       "    {- I -}",
+                                       "else",
+                                       "    {- J -}",
+                                       "    3"
+                                     ]
+      it "formats indented comments after else body" $
+        [ "if x then 1",
+          "else 2{-A-}",
+          " {-B-}"
+        ]
+          `shouldFormatExpressionAs` [ "if x then",
+                                       "    1",
+                                       "else",
+                                       "    2",
+                                       "    {- A -} {- B -}"
+                                     ]
+
     describe "let" $ do
       it "formats comments" $
         ["let{-A-}x{-D-}={-E-}1{-B-}in{-C-}x"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -345,6 +345,26 @@ spec = do
                                        "x"
                                      ]
 
+    describe "case" $ do
+      it "formats comments" $
+        [ "case{-A-}x{-B-}of{-C-}",
+          "{-D-}",
+          " Nothing{-E-}->{-F-}y",
+          "{-H-}",
+          " _{-J-}->{-K-}z"
+        ]
+          `shouldFormatExpressionAs` [ "case {- A -} x {- B -} of",
+                                       "    {- C -} {- D -}",
+                                       "    Nothing {- E -} ->",
+                                       "        {- F -}",
+                                       "        y",
+                                       "",
+                                       "    {- H -}",
+                                       "    _ {- J -} ->",
+                                       "        {- K -}",
+                                       "        z"
+                                     ]
+
     describe "record" $ do
       describe "empty" $ do
         it "formats already formatted" $

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -348,21 +348,39 @@ spec = do
     describe "case" $ do
       it "formats comments" $
         [ "case{-A-}x{-B-}of{-C-}",
-          "{-D-}",
+          " {-D1-}",
+          "{-D2-}",
           " Nothing{-E-}->{-F-}y",
-          "{-H-}",
+          " {-H1-}",
+          "{-H2-}",
           " _{-J-}->{-K-}z"
         ]
           `shouldFormatExpressionAs` [ "case {- A -} x {- B -} of",
-                                       "    {- C -} {- D -}",
+                                       "    {- C -} {- D1 -} {- D2 -}",
                                        "    Nothing {- E -} ->",
                                        "        {- F -}",
                                        "        y",
                                        "",
-                                       "    {- H -}",
+                                       "    {- H1 -} {- H2 -}",
                                        "    _ {- J -} ->",
                                        "        {- K -}",
                                        "        z"
+                                     ]
+      it "formats indented comments after branches" $
+        [ "case x of",
+          " Nothing -> y{-A-}",
+          "  {-B-}",
+          " _ -> z{-C-}",
+          "  {-D-}"
+        ]
+          `shouldFormatExpressionAs` [ "case x of",
+                                       "    Nothing ->",
+                                       "        y",
+                                       "        {- A -} {- B -}",
+                                       "",
+                                       "    _ ->",
+                                       "        z",
+                                       "        {- C -} {- D -}"
                                      ]
 
     describe "record" $ do

--- a/tests/Parse/MultilineStringSpec.hs
+++ b/tests/Parse/MultilineStringSpec.hs
@@ -48,4 +48,4 @@ parse expectedStr =
             expectedStr == Utf8.toChars str
           _ ->
             False
-   in Helpers.checkSuccessfulParse Pattern.expression Error.Syntax.PStart isExpectedString
+   in Helpers.checkSuccessfulParse (fmap (\((pat, _), loc) -> (pat, loc)) Pattern.expression) Error.Syntax.PStart isExpectedString

--- a/tests/Parse/UnderscorePatternSpec.hs
+++ b/tests/Parse/UnderscorePatternSpec.hs
@@ -48,7 +48,7 @@ parse expectedName =
             expectedName == (Name.toChars name)
           _ ->
             False
-   in Helpers.checkSuccessfulParse Pattern.expression Error.Syntax.PStart isWildCardPattern
+   in Helpers.checkSuccessfulParse (fmap (\((pat, _), loc) -> (pat, loc)) Pattern.expression) Error.Syntax.PStart isWildCardPattern
 
 failToParse :: BS.ByteString -> IO ()
 failToParse =


### PR DESCRIPTION
- retain comments in `case` expressions:
  - [x] between `case` keyword and condition
  - [x] between condition and `of` keyword
  - [x] between `of` keyword and first branch
  - for each branch:
    - [x] between pattern and `->`
    - [x] between `->` and expression
    - [x] after the expression (indented)
  - [x] between branches
- retain comments in `if` expressions:
  - for each "if/then" clause:
    - [x] between `if` keyword and condition
    - [x] between condition and `then` keyword
    - [x] between `then` keyword and expression
    - [x] between expression and `else` keyword
  - [x] between `else` keyword and `if` keyword (will be moved to after `if`)
  - [x] between `else` keyword and final else expression
  - [x] after final else expression (indented)
