### PR TITLE
format: retain comments in arrays and records

### DIFF
--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -16,6 +16,7 @@ module AST.Source
     Pattern_ (..),
     RecordFieldPattern,
     RecordFieldPattern_ (..),
+    PArrayEntry,
     Type,
     Type_ (..),
     SourceOrder,
@@ -106,7 +107,7 @@ data Pattern_
   | PAlias Pattern (A.Located Name)
   | PCtor A.Region Name [([Comment], Pattern)]
   | PCtorQual A.Region Name Name [([Comment], Pattern)]
-  | PArray [Pattern]
+  | PArray [PArrayEntry]
   | PChr ES.String
   | PStr ES.String
   | PInt Int
@@ -116,6 +117,8 @@ type RecordFieldPattern = A.Located RecordFieldPattern_
 
 data RecordFieldPattern_ = RFPattern (A.Located Name) Pattern
   deriving (Show)
+
+type PArrayEntry = (Pattern, SC.PArrayEntryComments)
 
 -- TYPE
 

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -8,6 +8,7 @@ module AST.Source
     Expr,
     Expr_ (..),
     VarType (..),
+    ArrayEntry,
     IfBranch,
     CaseBranch,
     Def (..),
@@ -59,7 +60,7 @@ data Expr_
   | Float EF.Float
   | Var VarType Name
   | VarQual VarType Name Name
-  | Array [Expr]
+  | Array [ArrayEntry]
   | Op Name
   | Negate Expr
   | Binops [(Expr, [Comment], A.Located Name)] Expr
@@ -77,6 +78,9 @@ data Expr_
 
 data VarType = LowVar | CapVar
   deriving (Show)
+
+type ArrayEntry =
+  (Expr, SC.ArrayEntryComments)
 
 type IfBranch =
   (Expr, Expr, SC.IfBranchComments)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -135,7 +135,7 @@ data Type_
   | TVar Name
   | TType A.Region Name [([Comment], Type)]
   | TTypeQual A.Region Name Name [([Comment], Type)]
-  | TRecord [TRecordField] (Maybe (A.Located Name))
+  | TRecord [TRecordField] (Maybe (A.Located Name, SC.UpdateComments))
   deriving (Show)
 
 type TRecordField = (A.Located Name, Type, SC.RecordFieldComments)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -11,6 +11,7 @@ module AST.Source
     ArrayEntry,
     IfBranch,
     CaseBranch,
+    RecordField,
     Def (..),
     Pattern,
     Pattern_ (..),
@@ -72,8 +73,8 @@ data Expr_
   | Case Expr [CaseBranch] SC.CaseComments
   | Accessor Name
   | Access Expr (A.Located Name)
-  | Update Expr [(A.Located Name, Expr)]
-  | Record [(A.Located Name, Expr)]
+  | Update Expr [RecordField]
+  | Record [RecordField]
   | Parens [Comment] Expr [Comment]
   deriving (Show)
 
@@ -88,6 +89,9 @@ type IfBranch =
 
 type CaseBranch =
   (Pattern, Expr, SC.CaseBranchComments)
+
+type RecordField =
+  (A.Located Name, Expr, SC.RecordFieldComments)
 
 -- DEFINITIONS
 

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -20,6 +20,7 @@ module AST.Source
     PArrayEntry,
     Type,
     Type_ (..),
+    TRecordField,
     SourceOrder,
     Module (..),
     getName,
@@ -134,8 +135,10 @@ data Type_
   | TVar Name
   | TType A.Region Name [([Comment], Type)]
   | TTypeQual A.Region Name Name [([Comment], Type)]
-  | TRecord [(A.Located Name, Type)] (Maybe (A.Located Name))
+  | TRecord [TRecordField] (Maybe (A.Located Name))
   deriving (Show)
+
+type TRecordField = (A.Located Name, Type, SC.RecordFieldComments)
 
 -- MODULE
 

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -73,7 +73,7 @@ data Expr_
   | Case Expr [CaseBranch] SC.CaseComments
   | Accessor Name
   | Access Expr (A.Located Name)
-  | Update Expr [RecordField]
+  | Update Expr [RecordField] SC.UpdateComments
   | Record [RecordField]
   | Parens [Comment] Expr [Comment]
   deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -135,6 +135,12 @@ data CaseBranchComments = CaseBranchComments
   }
   deriving (Show)
 
+data UpdateComments = UpdateComments
+  { _beforeBase :: [Comment],
+    _afterBase :: [Comment]
+  }
+  deriving (Show)
+
 data RecordFieldComments = RecordFieldComments
   { _beforeFieldName :: [Comment],
     _afterFieldName :: [Comment],

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -134,3 +134,11 @@ data CaseBranchComments = CaseBranchComments
     _afterBranchBody :: [Comment]
   }
   deriving (Show)
+
+-- Patterns
+
+data PArrayEntryComments = PArrayEntryComments
+  { _beforePArrayEntry :: [Comment],
+    _afterPArrayEntry :: [Comment]
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -89,6 +89,12 @@ data ValueComments = ValueComments
 
 -- Expressions
 
+data ArrayEntryComments = ArrayEntryComments
+  { _beforeArrayEntry :: [Comment],
+    _afterArrayEntry :: [Comment]
+  }
+  deriving (Show)
+
 data LambdaComments = LambdaComments
   { _beforeArrow :: [Comment],
     _afterArrow :: [Comment]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -135,6 +135,14 @@ data CaseBranchComments = CaseBranchComments
   }
   deriving (Show)
 
+data RecordFieldComments = RecordFieldComments
+  { _beforeFieldName :: [Comment],
+    _afterFieldName :: [Comment],
+    _beforeFieldValue :: [Comment],
+    _afterFieldValue :: [Comment]
+  }
+  deriving (Show)
+
 -- Patterns
 
 data PArrayEntryComments = PArrayEntryComments

--- a/compiler/src/Canonicalize/Environment/Dups.hs
+++ b/compiler/src/Canonicalize/Environment/Dups.hs
@@ -52,20 +52,20 @@ detectHelp toError name values =
 
 -- CHECK FIELDS
 
-checkFields :: [(A.Located Name.Name, a)] -> Result.Result i w Error.Error (Map.Map Name.Name a)
+checkFields :: [(A.Located Name.Name, a, comments)] -> Result.Result i w Error.Error (Map.Map Name.Name a)
 checkFields fields =
   detect Error.DuplicateField (foldr addField none fields)
 
-addField :: (A.Located Name.Name, a) -> Dict a -> Dict a
-addField (A.At region name, value) dups =
+addField :: (A.Located Name.Name, a, comments) -> Dict a -> Dict a
+addField (A.At region name, value, _) dups =
   Map.insertWith OneOrMore.more name (OneOrMore.one (Info region value)) dups
 
-checkFields' :: (A.Region -> a -> b) -> [(A.Located Name.Name, a)] -> Result.Result i w Error.Error (Map.Map Name.Name b)
+checkFields' :: (A.Region -> a -> b) -> [(A.Located Name.Name, a, comments)] -> Result.Result i w Error.Error (Map.Map Name.Name b)
 checkFields' toValue fields =
   detect Error.DuplicateField (foldr (addField' toValue) none fields)
 
-addField' :: (A.Region -> a -> b) -> (A.Located Name.Name, a) -> Dict b -> Dict b
-addField' toValue (A.At region name, value) dups =
+addField' :: (A.Region -> a -> b) -> (A.Located Name.Name, a, comments) -> Dict b -> Dict b
+addField' toValue (A.At region name, value, _) dups =
   Map.insertWith OneOrMore.more name (OneOrMore.one (Info region (toValue region value))) dups
 
 -- BUILDING DICTIONARIES

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -136,7 +136,7 @@ getEdges edges (A.At _ tipe) =
     Src.TTypeQual _ _ _ args ->
       List.foldl' getEdges edges (fmap snd args)
     Src.TRecord fields _ ->
-      List.foldl' (\es (_, t) -> getEdges es t) edges fields
+      List.foldl' (\es (_, t, _) -> getEdges es t) edges fields
 
 -- CHECK FREE VARIABLES
 
@@ -194,7 +194,7 @@ addFreeVars freeVars (A.At region tipe) =
                 freeVars
               Just (A.At extRegion ext) ->
                 Map.insert ext extRegion freeVars
-       in List.foldl' (\fvs (_, t) -> addFreeVars fvs t) extFreeVars fields
+       in List.foldl' (\fvs (_, t, _) -> addFreeVars fvs t) extFreeVars fields
 
 -- ADD CTORS
 

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -192,7 +192,7 @@ addFreeVars freeVars (A.At region tipe) =
             case maybeExt of
               Nothing ->
                 freeVars
-              Just (A.At extRegion ext) ->
+              Just (A.At extRegion ext, _) ->
                 Map.insert ext extRegion freeVars
        in List.foldl' (\fvs (_, t, _) -> addFreeVars fvs t) extFreeVars fields
 

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -110,7 +110,7 @@ canonicalize env (A.At region expression) =
         Can.Access
           <$> canonicalize env record
           <*> Result.ok field
-      Src.Update baseRecord fields ->
+      Src.Update baseRecord fields _ ->
         let makeCanFields =
               Dups.checkFields' (\r t -> Can.FieldUpdate r <$> canonicalize env t) fields
          in Can.Update

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -67,7 +67,7 @@ canonicalize env (A.At region expression) =
           Src.LowVar -> findVarQual region env prefix name
           Src.CapVar -> toVarCtor name <$> Env.findCtorQual region env prefix name
       Src.Array exprs ->
-        Can.Array <$> traverse (canonicalize env) exprs
+        Can.Array <$> traverse (canonicalize env) (fmap fst exprs)
       Src.Op op ->
         do
           (Env.Binop _ home name annotation _ _) <- Env.findBinop region env op

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -250,7 +250,7 @@ addBindingsHelp bindings (A.At region pattern) =
     Src.PCtorQual _ _ _ patterns ->
       List.foldl' addBindingsHelp bindings (fmap snd patterns)
     Src.PArray patterns ->
-      List.foldl' addBindingsHelp bindings patterns
+      List.foldl' addBindingsHelp bindings (fmap fst patterns)
     Src.PAlias aliasPattern (A.At nameRegion name) ->
       Dups.insert name nameRegion nameRegion $
         addBindingsHelp bindings aliasPattern
@@ -358,7 +358,7 @@ getPatternNames names (A.At region pattern) =
     Src.PAlias ptrn name -> getPatternNames (name : names) ptrn
     Src.PCtor _ _ args -> List.foldl' getPatternNames names (fmap snd args)
     Src.PCtorQual _ _ _ args -> List.foldl' getPatternNames names (fmap snd args)
-    Src.PArray patterns -> List.foldl' getPatternNames names patterns
+    Src.PArray patterns -> List.foldl' getPatternNames names (fmap fst patterns)
     Src.PChr _ -> names
     Src.PStr _ -> names
     Src.PInt _ -> names

--- a/compiler/src/Canonicalize/Pattern.hs
+++ b/compiler/src/Canonicalize/Pattern.hs
@@ -69,7 +69,7 @@ canonicalize env (A.At region pattern) =
       Src.PCtorQual nameRegion home name patterns ->
         canonicalizeCtor env region name (fmap snd patterns) =<< Env.findCtorQual nameRegion env home name
       Src.PArray patterns ->
-        Can.PArray <$> canonicalizeList env patterns
+        Can.PArray <$> canonicalizeList env (fmap fst patterns)
       Src.PAlias ptrn (A.At reg name) ->
         do
           cpattern <- canonicalize env ptrn

--- a/compiler/src/Canonicalize/Type.hs
+++ b/compiler/src/Canonicalize/Type.hs
@@ -51,7 +51,7 @@ canonicalize env (A.At typeRegion tipe) =
     Src.TRecord fields ext ->
       do
         cfields <- sequenceA =<< Dups.checkFields (canonicalizeFields env fields)
-        return $ Can.TRecord cfields (fmap A.toValue ext)
+        return $ Can.TRecord cfields (fmap (A.toValue . fst) ext)
 
 canonicalizeFields :: Env.Env -> [Src.TRecordField] -> [(A.Located Name.Name, Result i w Can.FieldType, ())]
 canonicalizeFields env fields =

--- a/compiler/src/Canonicalize/Type.hs
+++ b/compiler/src/Canonicalize/Type.hs
@@ -53,11 +53,11 @@ canonicalize env (A.At typeRegion tipe) =
         cfields <- sequenceA =<< Dups.checkFields (canonicalizeFields env fields)
         return $ Can.TRecord cfields (fmap A.toValue ext)
 
-canonicalizeFields :: Env.Env -> [(A.Located Name.Name, Src.Type)] -> [(A.Located Name.Name, Result i w Can.FieldType)]
+canonicalizeFields :: Env.Env -> [(A.Located Name.Name, Src.Type)] -> [(A.Located Name.Name, Result i w Can.FieldType, ())]
 canonicalizeFields env fields =
   let len = fromIntegral (length fields)
       canonicalizeField index (name, srcType) =
-        (name, Can.FieldType index <$> canonicalize env srcType)
+        (name, Can.FieldType index <$> canonicalize env srcType, ())
    in zipWith canonicalizeField [0 .. len] fields
 
 -- CANONICALIZE TYPE

--- a/compiler/src/Canonicalize/Type.hs
+++ b/compiler/src/Canonicalize/Type.hs
@@ -53,10 +53,10 @@ canonicalize env (A.At typeRegion tipe) =
         cfields <- sequenceA =<< Dups.checkFields (canonicalizeFields env fields)
         return $ Can.TRecord cfields (fmap A.toValue ext)
 
-canonicalizeFields :: Env.Env -> [(A.Located Name.Name, Src.Type)] -> [(A.Located Name.Name, Result i w Can.FieldType, ())]
+canonicalizeFields :: Env.Env -> [Src.TRecordField] -> [(A.Located Name.Name, Result i w Can.FieldType, ())]
 canonicalizeFields env fields =
   let len = fromIntegral (length fields)
-      canonicalizeField index (name, srcType) =
+      canonicalizeField index (name, srcType, _) =
         (name, Can.FieldType index <$> canonicalize env srcType, ())
    in zipWith canonicalizeField [0 .. len] fields
 

--- a/compiler/src/Gren/Compiler/Type.hs
+++ b/compiler/src/Gren/Compiler/Type.hs
@@ -102,7 +102,7 @@ fromRawType (A.At _ astType) =
     Src.TTypeQual _ _ name args ->
       Type name (map (fromRawType . snd) args)
     Src.TRecord fields ext ->
-      let fromField (A.At _ field, tipe) = (field, fromRawType tipe)
+      let fromField (A.At _ field, tipe, _) = (field, fromRawType tipe)
        in Record
             (map fromField fields)
             (fmap A.toValue ext)

--- a/compiler/src/Gren/Compiler/Type.hs
+++ b/compiler/src/Gren/Compiler/Type.hs
@@ -105,7 +105,7 @@ fromRawType (A.At _ astType) =
       let fromField (A.At _ field, tipe, _) = (field, fromRawType tipe)
        in Record
             (map fromField fields)
-            (fmap A.toValue ext)
+            (fmap (A.toValue . fst) ext)
 
 -- JSON for PROGRAM
 

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -857,12 +857,12 @@ formatType = \case
                     formatType (A.toValue type_)
               ]
         )
-  Src.TRecord [] (Just base) ->
+  Src.TRecord [] (Just (base, _)) ->
     NoTypeParens $
       Block.line $
         utf8 $
           A.toValue base
-  Src.TRecord (first : rest) (Just base) ->
+  Src.TRecord (first : rest) (Just (base, SC.UpdateComments commentsBeforeBase commentsAfterBase)) ->
     NoTypeParens $
       extendedGroup
         '{'
@@ -870,7 +870,7 @@ formatType = \case
         ','
         ':'
         '}'
-        (Block.line $ utf8 $ A.toValue base)
+        (withCommentsStackAround commentsBeforeBase commentsAfterBase $ Block.line $ utf8 $ A.toValue base)
         (fmap formatField $ first :| rest)
     where
       formatField (field, type_, SC.RecordFieldComments commentsBeforeName commentsAfterName commentsBeforeValue commentsAfterValue) =

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -917,7 +917,12 @@ formatPattern = \case
   Src.PArray items ->
     NoPatternParens $
       group '[' ',' ']' False $
-        fmap (patternParensNone . formatPattern . A.toValue) items
+        fmap formatArrayPatternEntry items
+    where
+      formatArrayPatternEntry (pattern, SC.PArrayEntryComments commentsBefore commentsAfter) =
+        withCommentsAround commentsBefore commentsAfter $
+          patternParensNone $
+            formatPattern (A.toValue pattern)
   Src.PChr char ->
     NoPatternParens $
       formatString StringStyleChar char

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -136,8 +136,10 @@ extendedGroup open baseSep sep fieldSep close base fields =
                 NonEmpty.prependList (maybeToList before) $
                   NonEmpty.singleton $
                     spaceOrIndent
-                      [ key,
-                        Block.line $ Block.char7 fieldSep,
+                      [ spaceOrIndent
+                          [ key,
+                            Block.line $ Block.char7 fieldSep
+                          ],
                         value
                       ]
 

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -199,10 +199,9 @@ record start =
                   word1 0x7C {- vertical bar -} E.RecordPipe
                   commentsAfterBar <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentField
                   firstField <- chompField commentsAfterBar
-                  -- TODO: use commentsAfterOpenBrace
-                  -- TODO: use commentsAfterFirstTerm
+                  let comments = SC.UpdateComments commentsAfterOpenBrace commentsAfterFirstTerm
                   fields <- chompFields [firstField]
-                  addEnd start (Src.Update firstTerm fields),
+                  addEnd start (Src.Update firstTerm fields comments),
                 do
                   word1 0x3D {-=-} E.RecordEquals
                   commentsAfterEquals <- Space.chompAndCheckIndent E.RecordSpace E.RecordIndentExpr

--- a/compiler/src/Parse/Type.hs
+++ b/compiler/src/Parse/Type.hs
@@ -67,11 +67,10 @@ term =
                     [ do
                         word1 0x7C E.TRecordColon
                         commentsAfterBar <- Space.chompAndCheckIndent E.TRecordSpace E.TRecordIndentField
+                        let baseComments = SC.UpdateComments commentsAfterOpenBrace commentsAfterFirstName
                         field <- chompField commentsAfterBar
                         fields <- chompRecordEnd [field]
-                        -- TODO: use commentsAfterOpenBrace
-                        -- TODO: use commentsAfterOpenFirstName
-                        addEnd start (Src.TRecord fields (Just name)),
+                        addEnd start (Src.TRecord fields (Just (name, baseComments))),
                       do
                         word1 0x3A {-:-} E.TRecordColon
                         commentsAfterColon <- Space.chompAndCheckIndent E.TRecordSpace E.TRecordIndentType

--- a/compiler/src/Reporting/Render/Type.hs
+++ b/compiler/src/Reporting/Render/Type.hs
@@ -129,8 +129,8 @@ srcToDoc context (A.At _ tipe) =
         (map srcFieldToDocs fields)
         (fmap (D.fromName . A.toValue) ext)
 
-srcFieldToDocs :: (A.Located Name.Name, Src.Type) -> (Doc, Doc)
-srcFieldToDocs (A.At _ fieldName, fieldType) =
+srcFieldToDocs :: Src.TRecordField -> (Doc, Doc)
+srcFieldToDocs (A.At _ fieldName, fieldType, _) =
   ( D.fromName fieldName,
     srcToDoc None fieldType
   )

--- a/compiler/src/Reporting/Render/Type.hs
+++ b/compiler/src/Reporting/Render/Type.hs
@@ -127,7 +127,7 @@ srcToDoc context (A.At _ tipe) =
     Src.TRecord fields ext ->
       record
         (map srcFieldToDocs fields)
-        (fmap (D.fromName . A.toValue) ext)
+        (fmap (D.fromName . A.toValue . fst) ext)
 
 srcFieldToDocs :: Src.TRecordField -> (Doc, Doc)
 srcFieldToDocs (A.At _ fieldName, fieldType, _) =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -518,6 +518,26 @@ spec = do
                                  "  b {- F -} : {- G -} Int {- H -}",
                                  "}"
                                ]
+    describe "record extension types" $ do
+      it "formats" $
+        ["{base|a:Bool,b:Int}"]
+          `shouldFormatTypeAs` [ "{ base",
+                                 "    | a : Bool",
+                                 "    , b : Int",
+                                 "}"
+                               ]
+      it "formats with comments" $
+        ["{{-A-}base{-B-}|{-C-}a{-D-}:{-E-}Bool{-F-},{-G-}b{-H-}:{-I-}Int{-J-}}"]
+          `shouldFormatTypeAs` [ "{ {- A -}",
+                                 "  base",
+                                 "  {- B -}",
+                                 "    | {- C -}",
+                                 "      a {- D -} : {- E -} Bool {- F -}",
+                                 "",
+                                 "    , {- G -}",
+                                 "      b {- H -} : {- I -} Int {- J -}",
+                                 "}"
+                               ]
 
 assertFormatted :: [Text] -> IO ()
 assertFormatted lines_ =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -464,6 +464,14 @@ spec = do
         assertFormattedExpression
           ["({- A -} x)"]
 
+  describe "patterns" $ do
+    describe "array patterns" $ do
+      it "formats comments" $
+        ["f [{-A-}1{-B-},{-C-}2{-D-}] = {}"]
+          `shouldFormatModuleBodyAs` [ "f [ {- A -} 1 {- B -}, {- C -} 2 {- D -} ] =",
+                                       "    {}"
+                                     ]
+
 assertFormatted :: [Text] -> IO ()
 assertFormatted lines_ =
   lines_ `shouldFormatAs` lines_

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -451,6 +451,15 @@ spec = do
                                        ", b = 2",
                                        "}"
                                      ]
+      it "formats field with multiline value" $
+        [ "{a = --X",
+          "1}"
+        ]
+          `shouldFormatExpressionAs` [ "{ a =",
+                                       "    -- X",
+                                       "    1",
+                                       "}"
+                                     ]
       it "formats comments" $
         ["{{-A-}a{-B-}={-C-}1{-D-},{-E-}b{-F-}={-G-}2{-H-}}"]
           `shouldFormatExpressionAs` [ "{ {- A -}",
@@ -466,6 +475,16 @@ spec = do
           `shouldFormatExpressionAs` [ "{ base",
                                        "    | a = 1",
                                        "    , b = 2",
+                                       "}"
+                                     ]
+      it "formats field with multiline value" $
+        [ "{base|a = --X",
+          "1}"
+        ]
+          `shouldFormatExpressionAs` [ "{ base",
+                                       "    | a =",
+                                       "        -- X",
+                                       "        1",
                                        "}"
                                      ]
       it "formats with comments" $

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -460,6 +460,14 @@ spec = do
                                        "  b {- F -} = {- G -} 2 {- H -}",
                                        "}"
                                      ]
+    describe "record update" $ do
+      it "formats" $
+        ["{base|a=1,b=2}"]
+          `shouldFormatExpressionAs` [ "{ base",
+                                       "    | a = 1",
+                                       "    , b = 2",
+                                       "}"
+                                     ]
 
   describe "parentheses" $ do
     it "removes unnecessary parentheses" $

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -451,6 +451,15 @@ spec = do
                                        ", b = 2",
                                        "}"
                                      ]
+      it "formats comments" $
+        ["{{-A-}a{-B-}={-C-}1{-D-},{-E-}b{-F-}={-G-}2{-H-}}"]
+          `shouldFormatExpressionAs` [ "{ {- A -}",
+                                       "  a {- B -} = {- C -} 1 {- D -}",
+                                       "",
+                                       ", {- E -}",
+                                       "  b {- F -} = {- G -} 2 {- H -}",
+                                       "}"
+                                     ]
 
   describe "parentheses" $ do
     it "removes unnecessary parentheses" $

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -291,6 +291,31 @@ spec = do
                                      ]
 
   describe "expressions" $ do
+    describe "array literals" $ do
+      it "formats" $
+        ["[1,2,3]"]
+          `shouldFormatExpressionAs` [ "[ 1",
+                                       ", 2",
+                                       ", 3",
+                                       "]"
+                                     ]
+
+      it "formats comments" $
+        ["[{-A-}1{-B-},{-C-}2{-D-},{-E-}3{-F-}]"]
+          `shouldFormatExpressionAs` [ "[ {- A -}",
+                                       "  1",
+                                       "    {- B -}",
+                                       "",
+                                       ", {- C -}",
+                                       "  2",
+                                       "    {- D -}",
+                                       "",
+                                       ", {- E -}",
+                                       "  3",
+                                       "    {- F -}",
+                                       "]"
+                                     ]
+
     describe "lambda" $ do
       it "formats comments" $
         ["\\{-A-}x{-B-}y{-C-}->{-D-}[]"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -468,6 +468,18 @@ spec = do
                                        "    , b = 2",
                                        "}"
                                      ]
+      it "formats with comments" $
+        ["{{-A-}base{-B-}|{-C-}a{-D-}={-E-}1{-F-},{-G-}b{-H-}={-I-}2{-J-}}"]
+          `shouldFormatExpressionAs` [ "{ {- A -}",
+                                       "  base",
+                                       "  {- B -}",
+                                       "    | {- C -}",
+                                       "      a {- D -} = {- E -} 1 {- F -}",
+                                       "",
+                                       "    , {- G -}",
+                                       "      b {- H -} = {- I -} 2 {- J -}",
+                                       "}"
+                                     ]
 
   describe "parentheses" $ do
     it "removes unnecessary parentheses" $

--- a/tests/Parse/RecordUpdateSpec.hs
+++ b/tests/Parse/RecordUpdateSpec.hs
@@ -56,7 +56,7 @@ parse str =
 isUpdateExpr :: Either x ((Src.Expr, [Src.Comment]), A.Position) -> Bool
 isUpdateExpr result =
   case result of
-    Right ((A.At _ (Src.Update _ _), _), _) -> True
+    Right ((A.At _ (Src.Update _ _ _), _), _) -> True
     _ -> False
 
 --


### PR DESCRIPTION
- retain comments in array expressions
  - [x] before each item
  - [x] after each item
  - (not included in this PR: in an empty array)
- retain comments in array patterns
  - [x] before each item
  - [x] after each item
  - (not included in this PR: in an empty array pattern)
- retain comments in record expressions
  - [x] (for record update) between `{` and base
  - [x] (for record update) between base and `|`
  - [x] before each field name
  - [x] between each field name and `=`
  - [x] between each `=` and value
  - [x] after each value
  - (not included in this PR: in an empty record)
- retain comments in record types
  - [x] (for record extension) between `{` and base
  - [x] (for record extension) between base and `|`
  - [x] before each field name
  - [x] between each field name and `:`
  - [x] between each `:` and field type
  - [x] after each field type
  - (not included in this PR: in an empty record type)
- (not included in this PR: retain comments in record patterns)