### PR TITLE
format: retain comments in remaining expressions

### DIFF
--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -9,6 +9,7 @@ module AST.Source
     Expr_ (..),
     VarType (..),
     ArrayEntry,
+    BinopsSegment,
     IfBranch,
     CaseBranch,
     RecordField,
@@ -66,7 +67,7 @@ data Expr_
   | Array [ArrayEntry]
   | Op Name
   | Negate Expr
-  | Binops [(Expr, [Comment], A.Located Name)] Expr
+  | Binops [BinopsSegment] Expr
   | Lambda [([Comment], Pattern)] Expr SC.LambdaComments
   | Call Expr [([Comment], Expr)]
   | If [IfBranch] Expr SC.IfComments
@@ -84,6 +85,9 @@ data VarType = LowVar | CapVar
 
 type ArrayEntry =
   (Expr, SC.ArrayEntryComments)
+
+type BinopsSegment =
+  (Expr, A.Located Name, SC.BinopsSegmentComments)
 
 type IfBranch =
   (Expr, Expr, SC.IfBranchComments)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -101,7 +101,7 @@ type RecordField =
 -- DEFINITIONS
 
 data Def
-  = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type) SC.ValueComments
+  = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe (Type, SC.ValueTypeComments)) SC.ValueComments
   | Destruct Pattern Expr
   deriving (Show)
 
@@ -184,7 +184,7 @@ data Import = Import
   }
   deriving (Show)
 
-data Value = Value (A.Located Name) [([Comment], Pattern)] Expr (Maybe Type) SC.ValueComments
+data Value = Value (A.Located Name) [([Comment], Pattern)] Expr (Maybe (Type, SC.ValueTypeComments)) SC.ValueComments
   deriving (Show)
 
 data Union = Union (A.Located Name) [A.Located Name] [(A.Located Name, [([Comment], Type)])]

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -102,7 +102,7 @@ type RecordField =
 
 data Def
   = Define (A.Located Name) [([Comment], Pattern)] Expr (Maybe (Type, SC.ValueTypeComments)) SC.ValueComments
-  | Destruct Pattern Expr
+  | Destruct Pattern Expr SC.ValueComments
   deriving (Show)
 
 -- PATTERN

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -89,6 +89,12 @@ data ValueComments = ValueComments
 
 -- Expressions
 
+data BinopsSegmentComments = BinopsSegmentComments
+  { _beforeOperator :: [Comment],
+    _afterOperator :: [Comment]
+  }
+  deriving (Show)
+
 data ArrayEntryComments = ArrayEntryComments
   { _beforeArrayEntry :: [Comment],
     _afterArrayEntry :: [Comment]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -87,6 +87,13 @@ data ValueComments = ValueComments
   }
   deriving (Show)
 
+data ValueTypeComments = ValueTypeComments
+  { _beforeTypeColon :: [Comment],
+    _afterTypeColon :: [Comment],
+    _afterValueType :: [Comment]
+  }
+  deriving (Show)
+
 -- Expressions
 
 data BinopsSegmentComments = BinopsSegmentComments

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -233,7 +233,7 @@ addBindings bindings (A.At _ def) =
   case def of
     Src.Define (A.At region name) _ _ _ _ ->
       Dups.insert name region region bindings
-    Src.Destruct pattern _ ->
+    Src.Destruct pattern _ _ ->
       addBindingsHelp bindings pattern
 
 addBindingsHelp :: Dups.Dict A.Region -> Src.Pattern -> Dups.Dict A.Region
@@ -307,7 +307,7 @@ addDefNodes env nodes (A.At _ def) =
             let cdef = Can.TypedDef aname freeVars args cbody resultType
             let node = (Define cdef, name, Map.keys freeLocals)
             logLetLocals args freeLocals (node : nodes)
-    Src.Destruct pattern body ->
+    Src.Destruct pattern body _ ->
       do
         (cpattern, _bindings) <-
           Pattern.verify Error.DPDestruct $

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -291,7 +291,7 @@ addDefNodes env nodes (A.At _ def) =
             let cdef = Can.Def aname args cbody
             let node = (Define cdef, name, Map.keys freeLocals)
             logLetLocals args freeLocals (node : nodes)
-        Just tipe ->
+        Just (tipe, _) ->
           do
             (Can.Forall freeVars ctipe) <- Type.toAnnotation env tipe
             ((args, resultType), argBindings) <-

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -149,9 +149,9 @@ canonicalizeCaseBranch env (pattern, expr, _) =
 
 -- CANONICALIZE BINOPS
 
-canonicalizeBinops :: A.Region -> Env.Env -> [(Src.Expr, [Src.Comment], A.Located Name.Name)] -> Src.Expr -> Result FreeLocals [W.Warning] Can.Expr
+canonicalizeBinops :: A.Region -> Env.Env -> [Src.BinopsSegment] -> Src.Expr -> Result FreeLocals [W.Warning] Can.Expr
 canonicalizeBinops overallRegion env ops final =
-  let canonicalizeHelp (expr, _, A.At region op) =
+  let canonicalizeHelp (expr, A.At region op, _) =
         (,)
           <$> canonicalize env expr
           <*> Env.findBinop region env op

--- a/compiler/src/Canonicalize/Module.hs
+++ b/compiler/src/Canonicalize/Module.hs
@@ -141,7 +141,7 @@ toNodeOne env (A.At _ (Src.Value aname@(A.At _ name) srcArgs body maybeType _)) 
             name,
             Map.keys freeLocals
           )
-    Just srcType ->
+    Just (srcType, _) ->
       do
         (Can.Forall freeVars tipe) <- Type.toAnnotation env srcType
 

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -778,13 +778,18 @@ formatDef (commentsBefore, def) =
     case A.toValue def of
       Src.Define name args body ann comments ->
         formatBasicDef (A.toValue name) args (A.toValue body) ann comments
-      Src.Destruct pat body ->
+      Src.Destruct pat body (SC.ValueComments commentsBeforeEquals commentsBeforeBody commentsAfterBody) ->
         Block.stack
           [ spaceOrIndent
-              [ patternParensProtectSpaces $ formatPattern $ A.toValue pat,
+              [ withCommentsAround [] commentsBeforeEquals $
+                  patternParensProtectSpaces $
+                    formatPattern (A.toValue pat),
                 Block.line $ Block.char7 '='
               ],
-            Block.indent $ exprParensNone $ formatExpr $ A.toValue body
+            Block.indent $
+              withCommentsStackAround commentsBeforeBody commentsAfterBody $
+                exprParensNone $
+                  formatExpr (A.toValue body)
           ]
 
 data TypeBlock

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -613,7 +613,8 @@ formatExpr = \case
           :| fmap formatArg args
     where
       formatArg (commentsBefore, arg) =
-        exprParensProtectSpaces (formatExpr $ A.toValue arg)
+        withCommentsBefore commentsBefore $
+          exprParensProtectSpaces (formatExpr $ A.toValue arg)
   Src.If [] else_ _ ->
     formatExpr $ A.toValue else_
   Src.If (if_ : elseifs) else_ (SC.IfComments commentsBeforeElseBody commentsAfterElseBody) ->

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -435,16 +435,17 @@ formatBasicDef name args body type_ (SC.ValueComments commentsBeforeEquals comme
 formatTypeAnnotation :: Maybe String -> Name -> (Src.Type, SC.ValueTypeComments) -> Block
 formatTypeAnnotation prefix name (t, SC.ValueTypeComments commentsBeforeColon commentsAfterColon commentsAfterType) =
   spaceOrIndent $
-    NonEmpty.fromList $
-      catMaybes
-        [ Just $ Block.line $ withPrefix $ utf8 name,
-          formatCommentBlock commentsBeforeColon,
-          Just $ Block.line $ Block.char7 ':',
-          Just $
-            withCommentsAround commentsAfterColon commentsAfterType $
-              typeParensNone $
-                formatType (A.toValue t)
-        ]
+    [ spaceOrStack $
+        NonEmpty.fromList $
+          catMaybes
+            [ Just $ Block.line $ withPrefix $ utf8 name,
+              formatCommentBlock commentsBeforeColon,
+              Just $ Block.line $ Block.char7 ':'
+            ],
+      withCommentsAround commentsAfterColon commentsAfterType $
+        typeParensNone $
+          formatType (A.toValue t)
+    ]
   where
     withPrefix a =
       case prefix of

--- a/compiler/src/Parse/Declaration.hs
+++ b/compiler/src/Parse/Declaration.hs
@@ -79,16 +79,17 @@ valueDecl maybeDocs start =
           [ do
               word1 0x3A {-:-} E.DeclDefEquals
               let commentsBeforeColon = commentsAfterName
-              Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentType
+              commentsAfterColon <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentType
               ((tipe, commentsAfterTipe), _) <- specialize E.DeclDefType Type.expression
               Space.checkFreshLine E.DeclDefNameRepeat
               defName <- chompMatchingName name
               commentsAfterMatchingName <- Space.chompAndCheckIndent E.DeclDefSpace E.DeclDefIndentEquals
-              chompDefArgsAndBody maybeDocs start defName (Just tipe) [] commentsAfterMatchingName,
+              let tipeComments = SC.ValueTypeComments commentsBeforeColon commentsAfterColon commentsAfterTipe
+              chompDefArgsAndBody maybeDocs start defName (Just (tipe, tipeComments)) [] commentsAfterMatchingName,
             chompDefArgsAndBody maybeDocs start (A.at start end name) Nothing [] commentsAfterName
           ]
 
-chompDefArgsAndBody :: Maybe Src.DocComment -> A.Position -> A.Located Name.Name -> Maybe Src.Type -> [([Src.Comment], Src.Pattern)] -> [Src.Comment] -> Space.Parser E.DeclDef (Decl, [Src.Comment])
+chompDefArgsAndBody :: Maybe Src.DocComment -> A.Position -> A.Located Name.Name -> Maybe (Src.Type, SC.ValueTypeComments) -> [([Src.Comment], Src.Pattern)] -> [Src.Comment] -> Space.Parser E.DeclDef (Decl, [Src.Comment])
 chompDefArgsAndBody maybeDocs start name tipe revArgs commentsBefore =
   oneOf
     E.DeclDefEquals

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -573,12 +573,12 @@ destructure :: Space.Parser E.Let (A.Located Src.Def, [Src.Comment])
 destructure =
   specialize E.LetDestruct $
     do
-      start <- getPosition
+      start@(A.Position _ startCol) <- getPosition
       pattern <- specialize E.DestructPattern Pattern.term
       commentsAfterPattern <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentEquals
       word1 0x3D {-=-} E.DestructEquals
       commentsAfterEquals <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentBody
       ((expr, commentsAfter), end) <- specialize E.DestructBody expression
-      let commentsAfterBody = []
+      let (commentsAfterBody, commentsAfterDef) = List.span (A.isIndentedMoreThan startCol) commentsAfter
       let comments = SC.ValueComments commentsAfterPattern commentsAfterEquals commentsAfterBody
-      return ((A.at start end (Src.Destruct pattern expr comments), commentsAfter), end)
+      return ((A.at start end (Src.Destruct pattern expr comments), commentsAfterDef), end)

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -575,8 +575,10 @@ destructure =
     do
       start <- getPosition
       pattern <- specialize E.DestructPattern Pattern.term
-      Space.chompAndCheckIndent E.DestructSpace E.DestructIndentEquals
+      commentsAfterPattern <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentEquals
       word1 0x3D {-=-} E.DestructEquals
-      Space.chompAndCheckIndent E.DestructSpace E.DestructIndentBody
+      commentsAfterEquals <- Space.chompAndCheckIndent E.DestructSpace E.DestructIndentBody
       ((expr, commentsAfter), end) <- specialize E.DestructBody expression
-      return ((A.at start end (Src.Destruct pattern expr), commentsAfter), end)
+      let commentsAfterBody = []
+      let comments = SC.ValueComments commentsAfterPattern commentsAfterEquals commentsAfterBody
+      return ((A.at start end (Src.Destruct pattern expr comments), commentsAfter), end)

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -522,17 +522,17 @@ definition =
           E.DefEquals
           [ do
               word1 0x3A {-:-} E.DefEquals
-              let commentsBeforeColon = commentsAfterName
-              Space.chompAndCheckIndent E.DefSpace E.DefIndentType
+              commentsAfterColon <- Space.chompAndCheckIndent E.DefSpace E.DefIndentType
               ((tipe, commentsAfterTipe), _) <- specialize E.DefType Type.expression
               Space.checkAligned E.DefAlignment
               defName <- chompMatchingName name
               commentsAfterMatchingName <- Space.chompAndCheckIndent E.DefSpace E.DefIndentEquals
-              chompDefArgsAndBody start defName (Just tipe) [] commentsAfterMatchingName,
+              let tipeComments = SC.ValueTypeComments commentsAfterName commentsAfterColon commentsAfterTipe
+              chompDefArgsAndBody start defName (Just (tipe, tipeComments)) [] commentsAfterMatchingName,
             chompDefArgsAndBody start aname Nothing [] commentsAfterName
           ]
 
-chompDefArgsAndBody :: A.Position -> A.Located Name.Name -> Maybe Src.Type -> [([Src.Comment], Src.Pattern)] -> [Src.Comment] -> Space.Parser E.Def (A.Located Src.Def, [Src.Comment])
+chompDefArgsAndBody :: A.Position -> A.Located Name.Name -> Maybe (Src.Type, SC.ValueTypeComments) -> [([Src.Comment], Src.Pattern)] -> [Src.Comment] -> Space.Parser E.Def (A.Located Src.Def, [Src.Comment])
 chompDefArgsAndBody start@(A.Position _ startCol) name tipe revArgs commentsBefore =
   oneOf
     E.DefEquals

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -1,8 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
--- Temporary while implementing gren format
-{-# OPTIONS_GHC -Wno-error=unused-do-bind #-}
-{-# OPTIONS_GHC -Wno-error=unused-local-binds #-}
-{-# OPTIONS_GHC -Wno-error=unused-matches #-}
 
 module Parse.Expression
   ( expression,

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -332,6 +332,11 @@ spec = do
         ["\\{-A-}x{-B-}y{-C-}->{-D-}[]"]
           `shouldFormatExpressionAs` ["\\{- A -} x {- B -} y {- C -} -> {- D -} []"]
 
+    describe "function call" $ do
+      it "formats comments" $
+        ["f{-A-}x{-B-}y{-C-}z"]
+          `shouldFormatExpressionAs` ["f {- A -} x {- B -} y {- C -} z"]
+
     describe "if" $ do
       it "formats comments" $
         ["if{-A-}x{-B-}then{-C-}1{-D-}else{-E-}if{-F-}y{-G-}then{-H-}2{-I-}else{-J-}3"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -281,20 +281,19 @@ spec = do
                                        "    {- D -}",
                                        "    []"
                                      ]
-      it "formats indented comments after the body" $ do
+      it "formats indented comments after the body" $
         [ "f = []",
           " {-B-}"
-          ]
+        ]
           `shouldFormatModuleBodyAs` [ "f =",
                                        "    []",
                                        "    {- B -}"
                                      ]
       it "formats comments in type annotations" $
-        do
-          [ "f{-A-}:{-B-}Int{-C-}",
-            "f =",
-            "    0"
-            ]
+        [ "f{-A-}:{-B-}Int{-C-}",
+          "f =",
+          "    0"
+        ]
           `shouldFormatModuleBodyAs` [ "f {- A -} : {- B -} Int {- C -}",
                                        "f =",
                                        "    0"
@@ -643,8 +642,8 @@ shouldFormatModuleBodyAs inputLines expectedOutputLines =
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
       actualOutput = LTE.decodeUtf8 . Builder.toLazyByteString <$> Format.formatByteString Parse.Application input
    in case LazyText.stripPrefix "module Main exposing (..)\n\n\n\n" <$> actualOutput of
-        Left _ ->
-          expectationFailure "shouldFormatModuleBodyAs: failed to format"
+        Left err ->
+          expectationFailure ("shouldFormatModuleBodyAs: failed to format" <> show err)
         Right Nothing ->
           expectationFailure "shouldFormatModuleBodyAs: internal error: could not strip module header"
         Right (Just actualModuleBody) ->

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -398,6 +398,28 @@ spec = do
                                        "{- C -}",
                                        "x"
                                      ]
+      it "formats comments in type annotations" $
+        [ "let f{-A-}:{-B-}Int{-C-}",
+          "    f =",
+          "        0",
+          "in x"
+        ]
+          `shouldFormatExpressionAs` [ "let",
+                                       "    f {- A -} : {- B -} Int {- C -}",
+                                       "    f =",
+                                       "        0",
+                                       "in",
+                                       "x"
+                                     ]
+      it "formats comments in destructure declarations" $
+        ["let{ x, y }{-A-}={-B-}r in x"]
+          `shouldFormatExpressionAs` [ "let",
+                                       "    { x, y } {- A -} =",
+                                       "        {- B -}",
+                                       "        r",
+                                       "in",
+                                       "x"
+                                     ]
       it "formats comments between and after declarations" $
         [ "let",
           "    x = 1",

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -316,15 +316,26 @@ spec = do
                                        "]"
                                      ]
 
+    describe "unary operators (negation)" $ do
+      it "formats" $
+        ["-x"]
+          `shouldFormatExpressionAs` ["-x"]
+      it "formats multiline value" $
+        [ "-(x --A",
+          ")"
+        ]
+          `shouldFormatExpressionAs` [ "-(x",
+                                       "  -- A",
+                                       " )"
+                                     ]
+
     describe "binary operators" $ do
       it "formats" $
-        do
-          ["1+2*3"]
+        ["1+2*3"]
           `shouldFormatExpressionAs` ["1 + 2 * 3"]
 
       it "formats comments" $
-        do
-          ["1{-A-}+{-B-}2{-C-}*{-D-}3"]
+        ["1{-A-}+{-B-}2{-C-}*{-D-}3"]
           `shouldFormatExpressionAs` ["1 {- A -} + {- B -} 2 {- C -} * {- D -} 3"]
 
     describe "lambda" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -316,6 +316,17 @@ spec = do
                                        "]"
                                      ]
 
+    describe "binary operators" $ do
+      it "formats" $
+        do
+          ["1+2*3"]
+          `shouldFormatExpressionAs` ["1 + 2 * 3"]
+
+      it "formats comments" $
+        do
+          ["1{-A-}+{-B-}2{-C-}*{-D-}3"]
+          `shouldFormatExpressionAs` ["1 {- A -} + {- B -} 2 {- C -} * {- D -} 3"]
+
     describe "lambda" $ do
       it "formats comments" $
         ["\\{-A-}x{-B-}y{-C-}->{-D-}[]"]
@@ -469,6 +480,7 @@ spec = do
                                        "  b {- F -} = {- G -} 2 {- H -}",
                                        "}"
                                      ]
+
     describe "record update" $ do
       it "formats" $
         ["{base|a=1,b=2}"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -126,7 +126,7 @@ spec = do
                            formattedModuleBody
                          ]
 
-  describe "top-level definition" $ do
+  describe "top-level definitions" $ do
     it "formats already formatted" $
       assertFormattedModuleBody
         [ "f x =",
@@ -288,6 +288,16 @@ spec = do
           `shouldFormatModuleBodyAs` [ "f =",
                                        "    []",
                                        "    {- B -}"
+                                     ]
+      it "formats comments in type annotations" $
+        do
+          [ "f{-A-}:{-B-}Int{-C-}",
+            "f =",
+            "    0"
+            ]
+          `shouldFormatModuleBodyAs` [ "f {- A -} : {- B -} Int {- C -}",
+                                       "f =",
+                                       "    0"
                                      ]
 
   describe "expressions" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -445,12 +445,18 @@ spec = do
         [ "let",
           "    x = 1",
           "     {-A-}",
+          "    {y,z} = r",
+          "     {-B-}",
           "in x"
         ]
           `shouldFormatExpressionAs` [ "let",
                                        "    x =",
                                        "        1",
                                        "        {- A -}",
+                                       "",
+                                       "    { y, z } =",
+                                       "        r",
+                                       "        {- B -}",
                                        "in",
                                        "x"
                                      ]


### PR DESCRIPTION
- [x] retain comments around binary operators
- [x] retain comments in declaration type annotations
- [x] retain comments in destructure declarations 