### PR TITLE
format: retain comments in remaining types

### DIFF
--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -29,6 +29,7 @@ module AST.Source
     Import (..),
     Value (..),
     Union (..),
+    UnionVariant,
     Alias (..),
     Infix (..),
     Port (..),
@@ -188,8 +189,11 @@ data Import = Import
 data Value = Value (A.Located Name) [([Comment], Pattern)] Expr (Maybe (Type, SC.ValueTypeComments)) SC.ValueComments
   deriving (Show)
 
-data Union = Union (A.Located Name) [A.Located Name] [(A.Located Name, [([Comment], Type)])]
+data Union = Union (A.Located Name) [([Comment], A.Located Name)] [UnionVariant] SC.UnionComments
   deriving (Show)
+
+type UnionVariant =
+  ([Comment], A.Located Name, [([Comment], Type)], [Comment])
 
 data Alias = Alias (A.Located Name) [A.Located Name] Type
   deriving (Show)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -140,6 +140,7 @@ data Type_
   | TType A.Region Name [([Comment], Type)]
   | TTypeQual A.Region Name Name [([Comment], Type)]
   | TRecord [TRecordField] (Maybe (A.Located Name, SC.UpdateComments))
+  | TParens Type SC.TParensComments
   deriving (Show)
 
 type TRecordField = (A.Located Name, Type, SC.RecordFieldComments)

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -135,7 +135,7 @@ type Type =
   A.Located Type_
 
 data Type_
-  = TLambda Type Type
+  = TLambda Type Type SC.TLambdaComments
   | TVar Name
   | TType A.Region Name [([Comment], Type)]
   | TTypeQual A.Region Name Name [([Comment], Type)]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -169,3 +169,11 @@ data PArrayEntryComments = PArrayEntryComments
     _afterPArrayEntry :: [Comment]
   }
   deriving (Show)
+
+-- Types
+
+data TParensComments = TParensComments
+  { _afterOpening :: [Comment],
+    _beforeClosing :: [Comment]
+  }
+  deriving (Show)

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -172,6 +172,12 @@ data PArrayEntryComments = PArrayEntryComments
 
 -- Types
 
+data TLambdaComments = TLambdaComments
+  { _beforeTArrow :: [Comment],
+    _afterTArrow :: [Comment]
+  }
+  deriving (Show)
+
 data TParensComments = TParensComments
   { _afterOpening :: [Comment],
     _beforeClosing :: [Comment]

--- a/compiler/src/AST/SourceComments.hs
+++ b/compiler/src/AST/SourceComments.hs
@@ -94,6 +94,12 @@ data ValueTypeComments = ValueTypeComments
   }
   deriving (Show)
 
+data UnionComments = UnionComments
+  { _beforeUnionTypeName :: [Comment],
+    _afterUnionTypeArgs :: [Comment]
+  }
+  deriving (Show)
+
 -- Expressions
 
 data BinopsSegmentComments = BinopsSegmentComments

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -137,6 +137,8 @@ getEdges edges (A.At _ tipe) =
       List.foldl' getEdges edges (fmap snd args)
     Src.TRecord fields _ ->
       List.foldl' (\es (_, t, _) -> getEdges es t) edges fields
+    Src.TParens inner _ ->
+      getEdges edges inner
 
 -- CHECK FREE VARIABLES
 
@@ -195,6 +197,8 @@ addFreeVars freeVars (A.At region tipe) =
               Just (A.At extRegion ext, _) ->
                 Map.insert ext extRegion freeVars
        in List.foldl' (\fvs (_, t, _) -> addFreeVars fvs t) extFreeVars fields
+    Src.TParens inner _ ->
+      addFreeVars freeVars inner
 
 -- ADD CTORS
 

--- a/compiler/src/Canonicalize/Environment/Local.hs
+++ b/compiler/src/Canonicalize/Environment/Local.hs
@@ -127,7 +127,7 @@ toNode alias@(A.At _ (Src.Alias (A.At _ name) _ tipe)) =
 getEdges :: [Name.Name] -> Src.Type -> [Name.Name]
 getEdges edges (A.At _ tipe) =
   case tipe of
-    Src.TLambda arg result ->
+    Src.TLambda arg result _ ->
       getEdges (getEdges edges arg) result
     Src.TVar _ ->
       edges
@@ -181,7 +181,7 @@ checkAliasFreeVars (A.At aliasRegion (Src.Alias (A.At _ name) args tipe)) =
 addFreeVars :: Map.Map Name.Name A.Region -> Src.Type -> Map.Map Name.Name A.Region
 addFreeVars freeVars (A.At region tipe) =
   case tipe of
-    Src.TLambda arg result ->
+    Src.TLambda arg result _ ->
       addFreeVars (addFreeVars freeVars arg) result
     Src.TVar name ->
       Map.insert name region freeVars

--- a/compiler/src/Canonicalize/Type.hs
+++ b/compiler/src/Canonicalize/Type.hs
@@ -52,6 +52,8 @@ canonicalize env (A.At typeRegion tipe) =
       do
         cfields <- sequenceA =<< Dups.checkFields (canonicalizeFields env fields)
         return $ Can.TRecord cfields (fmap (A.toValue . fst) ext)
+    Src.TParens inner _ ->
+      canonicalize env inner
 
 canonicalizeFields :: Env.Env -> [Src.TRecordField] -> [(A.Located Name.Name, Result i w Can.FieldType, ())]
 canonicalizeFields env fields =

--- a/compiler/src/Canonicalize/Type.hs
+++ b/compiler/src/Canonicalize/Type.hs
@@ -44,7 +44,7 @@ canonicalize env (A.At typeRegion tipe) =
     Src.TTypeQual region home name args ->
       canonicalizeType env typeRegion name (fmap snd args)
         =<< Env.findTypeQual region env home name
-    Src.TLambda a b ->
+    Src.TLambda a b _ ->
       Can.TLambda
         <$> canonicalize env a
         <*> canonicalize env b

--- a/compiler/src/Gren/Compiler/Type.hs
+++ b/compiler/src/Gren/Compiler/Type.hs
@@ -106,6 +106,8 @@ fromRawType (A.At _ astType) =
        in Record
             (map fromField fields)
             (fmap (A.toValue . fst) ext)
+    Src.TParens inner _ ->
+      fromRawType inner
 
 -- JSON for PROGRAM
 

--- a/compiler/src/Gren/Compiler/Type.hs
+++ b/compiler/src/Gren/Compiler/Type.hs
@@ -93,7 +93,7 @@ decoder =
 fromRawType :: Src.Type -> Type
 fromRawType (A.At _ astType) =
   case astType of
-    Src.TLambda t1 t2 ->
+    Src.TLambda t1 t2 _ ->
       Lambda (fromRawType t1) (fromRawType t2)
     Src.TVar x ->
       Var x

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -857,10 +857,10 @@ formatType = \case
     TypeContainsSpaces $
       spaceOrIndent $
         Block.line (utf8 name)
-          :| fmap (typeParensProtectSpaces . formatArg) args
+          :| fmap formatArg args
     where
       formatArg (comments, arg) =
-        formatType (A.toValue arg)
+        withCommentsBefore comments $ typeParensProtectSpaces $ formatType (A.toValue arg)
   Src.TTypeQual _ ns name [] ->
     NoTypeParens $
       Block.line (utf8 ns <> Block.char7 '.' <> utf8 name)
@@ -868,10 +868,10 @@ formatType = \case
     TypeContainsSpaces $
       spaceOrIndent $
         Block.line (utf8 ns <> Block.char7 '.' <> utf8 name)
-          :| fmap (typeParensProtectSpaces . formatArg) args
+          :| fmap formatArg args
     where
       formatArg (comments, arg) =
-        formatType (A.toValue arg)
+        withCommentsBefore comments $ typeParensProtectSpaces $ formatType (A.toValue arg)
   Src.TRecord fields Nothing ->
     NoTypeParens $
       groupWithBlankLines '{' ',' '}' True $

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -166,7 +166,7 @@ getDocComments decls comments =
     decl : otherDecls ->
       case decl of
         Decl.Value c (A.At _ (Src.Value n _ _ _ _)) -> getDocComments otherDecls (addComment c n comments)
-        Decl.Union c (A.At _ (Src.Union n _ _)) -> getDocComments otherDecls (addComment c n comments)
+        Decl.Union c (A.At _ (Src.Union n _ _ _)) -> getDocComments otherDecls (addComment c n comments)
         Decl.Alias c (A.At _ (Src.Alias n _ _)) -> getDocComments otherDecls (addComment c n comments)
         Decl.Port c (Src.Port n _) -> getDocComments otherDecls (addComment c n comments)
         Decl.TopLevelComments _ -> getDocComments otherDecls comments

--- a/compiler/src/Parse/Type.hs
+++ b/compiler/src/Parse/Type.hs
@@ -1,7 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
--- Temporary while implementing gren format
-{-# OPTIONS_GHC -Wno-error=unused-do-bind #-}
-{-# OPTIONS_GHC -Wno-error=unused-matches #-}
 
 module Parse.Type
   ( expression,

--- a/compiler/src/Parse/Type.hs
+++ b/compiler/src/Parse/Type.hs
@@ -107,7 +107,8 @@ expression =
           word2 0x2D 0x3E {-->-} E.TStart -- could just be another type instead
           commentsAfterArrow <- Space.chompAndCheckIndent E.TSpace E.TIndentStart
           ((tipe2, commentsAfter), end2) <- expression
-          let tipe = A.at start end2 (Src.TLambda tipe1 tipe2)
+          let comments = SC.TLambdaComments commentsBeforeArrow commentsAfterArrow
+          let tipe = A.at start end2 (Src.TLambda tipe1 tipe2 comments)
           return ((tipe, commentsAfter), end2)
       ]
       term1

--- a/compiler/src/Parse/Type.hs
+++ b/compiler/src/Parse/Type.hs
@@ -45,11 +45,12 @@ term =
         -- parenthesis
         inContext E.TParenthesis (word1 0x28 {-(-} E.TStart) $
           do
-            commentsBeforeOpeningParen <- Space.chompAndCheckIndent E.TParenthesisSpace E.TParenthesisIndentOpen
+            commentsAfterOpeningParen <- Space.chompAndCheckIndent E.TParenthesisSpace E.TParenthesisIndentOpen
             ((tipe, commentsBeforeClosingParen), end) <- specialize E.TParenthesisType expression
             Space.checkIndent end E.TParenthesisIndentEnd
             word1 0x29 {-)-} E.TParenthesisEnd
-            return tipe,
+            let comments = SC.TParensComments commentsAfterOpeningParen commentsBeforeClosingParen
+            addEnd start (Src.TParens tipe comments),
         -- records
         inContext E.TRecord (word1 0x7B {- { -} E.TStart) $
           do

--- a/compiler/src/Reporting/Render/Type.hs
+++ b/compiler/src/Reporting/Render/Type.hs
@@ -128,6 +128,8 @@ srcToDoc context (A.At _ tipe) =
       record
         (map srcFieldToDocs fields)
         (fmap (D.fromName . A.toValue . fst) ext)
+    Src.TParens inner _ ->
+      srcToDoc context inner
 
 srcFieldToDocs :: Src.TRecordField -> (Doc, Doc)
 srcFieldToDocs (A.At _ fieldName, fieldType, _) =

--- a/compiler/src/Reporting/Render/Type.hs
+++ b/compiler/src/Reporting/Render/Type.hs
@@ -105,7 +105,7 @@ vrecord entries maybeExt =
 srcToDoc :: Context -> Src.Type -> Doc
 srcToDoc context (A.At _ tipe) =
   case tipe of
-    Src.TLambda arg1 result ->
+    Src.TLambda arg1 result _ ->
       let (arg2, rest) = collectSrcArgs result
        in lambda
             context
@@ -140,7 +140,7 @@ srcFieldToDocs (A.At _ fieldName, fieldType, _) =
 collectSrcArgs :: Src.Type -> (Src.Type, [Src.Type])
 collectSrcArgs tipe =
   case tipe of
-    A.At _ (Src.TLambda a result) ->
+    A.At _ (Src.TLambda a result _) ->
       let (b, cs) = collectSrcArgs result
        in (a, b : cs)
     _ ->

--- a/terminal/src/Repl.hs
+++ b/terminal/src/Repl.hs
@@ -283,7 +283,7 @@ attemptDeclOrExpr lines =
         Right ((decl, _), _) ->
           case decl of
             PD.Value _ (A.At _ (Src.Value (A.At _ name) _ _ _ _)) -> ifDone lines (Decl name src)
-            PD.Union _ (A.At _ (Src.Union (A.At _ name) _ _)) -> ifDone lines (Type name src)
+            PD.Union _ (A.At _ (Src.Union (A.At _ name) _ _ _)) -> ifDone lines (Type name src)
             PD.Alias _ (A.At _ (Src.Alias (A.At _ name) _ _)) -> ifDone lines (Type name src)
             PD.Port _ _ -> Done Port
             PD.TopLevelComments _ -> Done Skip

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -626,6 +626,9 @@ spec = do
       it "removes unnecessary parens" $
         ["((a -> b)) -> c"]
           `shouldFormatTypeAs` ["(a -> b) -> c"]
+      it "formats comments" $
+        ["({-A-}Int{-B-})"]
+          `shouldFormatTypeAs` ["({- A -} Int {- B -})"]
 
 assertFormatted :: [Text] -> IO ()
 assertFormatted lines_ =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -586,6 +586,12 @@ spec = do
                                      ]
 
   describe "types" $ do
+    describe "function types" $ do
+      it "formats comments" $
+        do
+          ["a{-A-}->{-B-}b"]
+          `shouldFormatTypeAs` ["a {- A -} -> {- B -} b"]
+
     describe "record types" $ do
       it "formats with fields" $
         ["{a:Bool,   b : Int}"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -622,6 +622,10 @@ spec = do
                                  "      b {- H -} : {- I -} Int {- J -}",
                                  "}"
                                ]
+    describe "parentheses" $ do
+      it "removes unnecessary parens" $
+        ["((a -> b)) -> c"]
+          `shouldFormatTypeAs` ["(a -> b) -> c"]
 
 assertFormatted :: [Text] -> IO ()
 assertFormatted lines_ =

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -607,9 +607,11 @@ spec = do
 
   describe "types" $ do
     describe "function types" $ do
+      it "formats" $
+        ["a->b->c->d"]
+          `shouldFormatTypeAs` ["a -> b -> c -> d"]
       it "formats comments" $
-        do
-          ["a{-A-}->{-B-}b"]
+        ["a{-A-}->{-B-}b"]
           `shouldFormatTypeAs` ["a {- A -} -> {- B -} b"]
 
     describe "type with arguments" $ do

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -592,6 +592,14 @@ spec = do
           ["a{-A-}->{-B-}b"]
           `shouldFormatTypeAs` ["a {- A -} -> {- B -} b"]
 
+    describe "type with arguments" $ do
+      it "formats comments" $
+        ["Dict{-A-}Int{-B-}String"]
+          `shouldFormatTypeAs` ["Dict {- A -} Int {- B -} String"]
+      it "formats comments for qualified types" $
+        ["Dict.Dict{-A-}Int{-B-}String"]
+          `shouldFormatTypeAs` ["Dict.Dict {- A -} Int {- B -} String"]
+
     describe "record types" $ do
       it "formats with fields" $
         ["{a:Bool,   b : Int}"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -274,6 +274,26 @@ spec = do
                                      "    {}"
                                    ]
 
+    describe "union type declarations" $ do
+      it "formats comments" $
+        ["type{-A-}T{-B-}a{-C-}b{-D-}={-E-}A{-F-}a{-G-}a{-H-}|{-I-}B{-J-}b"]
+          `shouldFormatModuleBodyAs` [ "type {- A -} T {- B -} a {- C -} b {- D -}",
+                                       "    = {- E -} A {- F -} a {- G -} a {- H -}",
+                                       "    | {- I -} B {- J -} b"
+                                     ]
+      it "formats indented comments after last variant" $
+        [ "type T = A{-A-}",
+          " {-B-}",
+          "{-C-}"
+        ]
+          `shouldFormatModuleBodyAs` [ "type T",
+                                       "    = A {- A -} {- B -}",
+                                       "",
+                                       "",
+                                       "",
+                                       "{- C -}"
+                                     ]
+
     describe "value declarations" $ do
       it "formats comments" $
         ["f{-A-}x{-B-}y{-C-}={-D-}[]"]


### PR DESCRIPTION
- retain comments in type parentheses
  - [x] after opening paren
  - [x] before closing paren
- retain comments in function types
  - [x] before arrow
  - [x] after arrow
- [x] retain comments before each type argument
- retain comments in union type declarations
  - [x] between `type` keyword and name
  - [x] before each argument
  - [x] between last argument (or name) and `=`
  - [x] between `=` or `|` and each variant
  - [x] before each argument to a variant
  - [x] between the end of a variant and the next `|`
  - [x] after the last variant (indented)
 