### PR TITLE
Fix stdout output when compiling docs

### DIFF
--- a/builder/src/Deps/Package.hs
+++ b/builder/src/Deps/Package.hs
@@ -6,6 +6,7 @@ module Deps.Package
     latestCompatibleVersionForPackages,
     --
     bumpPossibilities,
+    isPackageInCache,
     installPackageVersion,
   )
 where
@@ -119,6 +120,11 @@ sameMinor (V.Version major1 minor1 _) (V.Version major2 minor2 _) =
   major1 == major2 && minor1 == minor2
 
 -- INSTALL PACKAGE VERSION
+
+isPackageInCache :: Dirs.PackageCache -> Pkg.Name -> V.Version -> IO Bool
+isPackageInCache cache pkg vsn = do
+  let versionedPkgPath = Dirs.package cache pkg vsn
+  Dir.doesDirectoryExist versionedPkgPath
 
 installPackageVersion :: Dirs.PackageCache -> Pkg.Name -> V.Version -> IO (Either Git.Error ())
 installPackageVersion cache pkg vsn = do

--- a/builder/src/Git.hs
+++ b/builder/src/Git.hs
@@ -56,9 +56,8 @@ githubUrl pkg =
 --
 
 clone :: GitUrl -> V.Version -> FilePath -> IO (Either Error ())
-clone (GitUrl (pkgName, gitUrl)) vsn targetFolder = do
+clone (GitUrl (_, gitUrl)) vsn targetFolder = do
   maybeExec <- checkInstalledGit
-  putStrFlush $ "Cloning " ++ pkgName ++ " " ++ V.toChars vsn ++ "... "
   case maybeExec of
     Nothing ->
       return $ Left MissingGit
@@ -78,13 +77,10 @@ clone (GitUrl (pkgName, gitUrl)) vsn targetFolder = do
           ""
       case exitCode of
         Exit.ExitFailure 128 -> do
-          putStrLn "Error!"
           return $ Left $ NoSuchRepoOrVersion vsn
         Exit.ExitFailure _ -> do
-          putStrLn "Error!"
           return $ Left $ FailedCommand ("git" : args) stderr
         Exit.ExitSuccess -> do
-          putStrLn "Ok!"
           return $ Right ()
 
 tags :: GitUrl -> IO (Either Error (V.Version, [V.Version]))

--- a/terminal/src/Docs.hs
+++ b/terminal/src/Docs.hs
@@ -71,7 +71,7 @@ runHelp root style (Flags maybeOutput _) =
                 return ()
             Just DevStdOut ->
               do
-                docs <- buildExposed style root details Build.KeepDocs exposed
+                docs <- buildExposed Reporting.silent root details Build.KeepDocs exposed
                 let builder = Json.encodeUgly $ Docs.encode docs
                 Task.io $ B.hPutBuilder IO.stdout builder
             Nothing ->

--- a/terminal/src/Init.hs
+++ b/terminal/src/Init.hs
@@ -84,7 +84,7 @@ init flags =
       Left (DPkg.GitError gitError) ->
         return $ Left $ Exit.InitNoCompatibleDependencies $ Just gitError
       Right deps -> do
-        result <- Solver.verify cache platform deps
+        result <- Solver.verify Reporting.ignorer cache platform deps
         case result of
           Solver.Err exit ->
             return (Left (Exit.InitSolverProblem exit))

--- a/terminal/src/Make.hs
+++ b/terminal/src/Make.hs
@@ -56,9 +56,9 @@ data ReportType
 type Task a = Task.Task Exit.Make a
 
 run :: [FilePath] -> Flags -> IO ()
-run paths flags@(Flags _ _ _ report) =
+run paths flags@(Flags _ _ maybeOutput report) =
   do
-    style <- getStyle report
+    style <- getStyle maybeOutput report
     maybeRoot <- Dirs.findRoot
     Reporting.attemptWithStyle style Exit.makeToReport $
       case maybeRoot of
@@ -135,11 +135,12 @@ runHelp root paths style (Flags debug optimize maybeOutput _) =
 
 -- GET INFORMATION
 
-getStyle :: Maybe ReportType -> IO Reporting.Style
-getStyle report =
-  case report of
-    Nothing -> Reporting.terminal
-    Just Json -> return Reporting.json
+getStyle :: Maybe Output -> Maybe ReportType -> IO Reporting.Style
+getStyle maybeOutput report =
+  case (maybeOutput, report) of
+    (Just DevStdOut, _) -> return Reporting.silent
+    (_, Nothing) -> Reporting.terminal
+    (_, Just Json) -> return Reporting.json
 
 getMode :: Bool -> Bool -> Task DesiredMode
 getMode debug optimize =

--- a/terminal/src/Package/Uninstall.hs
+++ b/terminal/src/Package/Uninstall.hs
@@ -153,7 +153,7 @@ makeAppPlan (Solver.Env cache) pkg outline@(Outline.AppOutline _ rootPlatform _ 
     Just vsn -> do
       let constraints = toConstraints direct indirect
       let withMissingPkg = Map.delete pkg constraints
-      result <- Task.io $ Solver.verify cache rootPlatform withMissingPkg
+      result <- Task.io $ Solver.verify Reporting.ignorer cache rootPlatform withMissingPkg
       case result of
         Solver.Ok solution ->
           let old = Map.union direct indirect
@@ -184,7 +184,7 @@ makeAppPlan (Solver.Env cache) pkg outline@(Outline.AppOutline _ rootPlatform _ 
         Just _ -> do
           let constraints = toConstraints direct indirect
           let withMissingPkg = Map.delete pkg constraints
-          result <- Task.io $ Solver.verify cache rootPlatform withMissingPkg
+          result <- Task.io $ Solver.verify Reporting.ignorer cache rootPlatform withMissingPkg
           case result of
             Solver.Ok solution ->
               let old = Map.union direct indirect
@@ -229,7 +229,7 @@ makePkgPlan (Solver.Env cache) pkg outline@(Outline.PkgOutline _ _ _ _ _ deps _ 
     then return NoSuchPackage
     else do
       let withMissingPkg = Map.delete pkg deps
-      result <- Task.io $ Solver.verify cache rootPlatform withMissingPkg
+      result <- Task.io $ Solver.verify Reporting.ignorer cache rootPlatform withMissingPkg
       case result of
         Solver.Ok _ ->
           let changes = Map.difference deps withMissingPkg

--- a/terminal/src/Repl.hs
+++ b/terminal/src/Repl.hs
@@ -129,7 +129,7 @@ installDeps root =
         packageCache <- Dirs.getPackageCache
         let platform = Outline.platform outline
         let dependencies = Outline.dependencyConstraints outline
-        _ <- Solver.verify packageCache platform dependencies
+        _ <- Solver.verify Reporting.ignorer packageCache platform dependencies
         return ()
 
 -- LOOP


### PR DESCRIPTION
When compiling docs or source code with the `--output=/dev/stdout` flag, corrupted data would be the result due to some unfortunate `putStrLn`'s.

This should now be fixed.