### PR TITLE
format: (kernel modules) keep infix operators in the original order

### DIFF
--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -228,7 +228,7 @@ formatModule (Src.Module moduleName exports docs imports values unions aliases b
                   ],
           formatCommentBlock (commentsAfterLine <> commentsAfterDocComment),
           Just $ Block.stack $ Block.blankLine :| fmap formatImport imports,
-          infixDefs,
+          Block.stack . (Block.blankLine :|) . pure <$> infixDefs,
           let defs =
                 fmap snd $
                   List.sortOn fst $

--- a/compiler/src/Parse/Module.hs
+++ b/compiler/src/Parse/Module.hs
@@ -210,7 +210,7 @@ chompInfixes infixes =
         binop <- Decl.infix_
         chompInfixes (binop : infixes)
     ]
-    infixes
+    (reverse infixes)
 
 -- MODULE DOC COMMENT
 


### PR DESCRIPTION
Fixes a bug noted in Zulip, where `infix` top-level declarations would get reversed when formatted.  (Only applicable to kernel packages like `core`, since infix operator declarations aren't allowed elsewhere.)