### PR TITLE
format: good things to fix before 0.2

### DIFF
--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -50,6 +50,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Name (Name)
 import Data.Name qualified as Name
 import Gren.Float qualified as EF
+import Gren.Int qualified as GI
 import Gren.String qualified as ES
 import Parse.Primitives qualified as P
 import Reporting.Annotation qualified as A
@@ -61,7 +62,7 @@ type Expr = A.Located Expr_
 data Expr_
   = Chr ES.String
   | Str ES.String
-  | Int Int
+  | Int Int GI.IntFormat
   | Float EF.Float
   | Var VarType Name
   | VarQual VarType Name Name
@@ -120,7 +121,7 @@ data Pattern_
   | PArray [PArrayEntry]
   | PChr ES.String
   | PStr ES.String
-  | PInt Int
+  | PInt Int GI.IntFormat
   deriving (Show)
 
 type RecordFieldPattern = A.Located RecordFieldPattern_

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -61,7 +61,7 @@ type Expr = A.Located Expr_
 
 data Expr_
   = Chr ES.String
-  | Str ES.String
+  | Str ES.String ES.StringFormat
   | Int Int GI.IntFormat
   | Float EF.Float
   | Var VarType Name

--- a/compiler/src/AST/Source.hs
+++ b/compiler/src/AST/Source.hs
@@ -158,7 +158,7 @@ data Module = Module
     _values :: [(SourceOrder, A.Located Value)],
     _unions :: [(SourceOrder, A.Located Union)],
     _aliases :: [(SourceOrder, A.Located Alias)],
-    _binops :: [A.Located Infix],
+    _binops :: ([Comment], [A.Located Infix]),
     _topLevelComments :: [(SourceOrder, NonEmpty Comment)],
     _headerComments :: SC.HeaderComments,
     _effects :: Effects

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -50,7 +50,7 @@ canonicalize :: Env.Env -> Src.Expr -> Result FreeLocals [W.Warning] Can.Expr
 canonicalize env (A.At region expression) =
   A.At region
     <$> case expression of
-      Src.Str string ->
+      Src.Str string _ ->
         Result.ok (Can.Str string)
       Src.Chr char ->
         Result.ok (Can.Chr char)

--- a/compiler/src/Canonicalize/Expression.hs
+++ b/compiler/src/Canonicalize/Expression.hs
@@ -54,7 +54,7 @@ canonicalize env (A.At region expression) =
         Result.ok (Can.Str string)
       Src.Chr char ->
         Result.ok (Can.Chr char)
-      Src.Int int ->
+      Src.Int int _ ->
         Result.ok (Can.Int int)
       Src.Float float ->
         Result.ok (Can.Float float)
@@ -258,7 +258,7 @@ addBindingsHelp bindings (A.At region pattern) =
       bindings
     Src.PStr _ ->
       bindings
-    Src.PInt _ ->
+    Src.PInt _ _ ->
       bindings
 
 -- BUILD BINDINGS GRAPH
@@ -361,7 +361,7 @@ getPatternNames names (A.At region pattern) =
     Src.PArray patterns -> List.foldl' getPatternNames names (fmap fst patterns)
     Src.PChr _ -> names
     Src.PStr _ -> names
-    Src.PInt _ -> names
+    Src.PInt _ _ -> names
 
 extractRecordFieldPattern :: Src.RecordFieldPattern -> Src.Pattern
 extractRecordFieldPattern (A.At _ (Src.RFPattern _ pattern)) = pattern

--- a/compiler/src/Canonicalize/Module.hs
+++ b/compiler/src/Canonicalize/Module.hs
@@ -35,7 +35,7 @@ type Result i w a =
 -- MODULES
 
 canonicalize :: Pkg.Name -> Map.Map ModuleName.Raw I.Interface -> Src.Module -> Result i [W.Warning] Can.Module
-canonicalize pkg ifaces modul@(Src.Module _ exports docs imports valuesWithSourceOrder _ _ binops _ _ effects) =
+canonicalize pkg ifaces modul@(Src.Module _ exports docs imports valuesWithSourceOrder _ _ (_, binops) _ _ effects) =
   do
     let values = fmap snd valuesWithSourceOrder
     let home = ModuleName.Canonical pkg (Src.getName modul)

--- a/compiler/src/Canonicalize/Pattern.hs
+++ b/compiler/src/Canonicalize/Pattern.hs
@@ -78,7 +78,7 @@ canonicalize env (A.At region pattern) =
         Result.ok (Can.PChr chr)
       Src.PStr str ->
         Result.ok (Can.PStr str)
-      Src.PInt int ->
+      Src.PInt int _ ->
         Result.ok (Can.PInt int)
 
 canonicalizeRecordFields :: Env.Env -> [Src.RecordFieldPattern] -> Result DupsDict w [Can.PatternRecordField]

--- a/compiler/src/Data/Utf8.hs
+++ b/compiler/src/Data/Utf8.hs
@@ -23,6 +23,7 @@ module Data.Utf8
     putVeryLong,
     --
     toChars,
+    toText,
     toBuilder,
     toEscapedBuilder,
     --
@@ -46,6 +47,7 @@ import Data.ByteString.Builder.Internal qualified as B
 import Data.ByteString.Internal qualified as B
 import Data.Char qualified as Char
 import Data.List qualified as List
+import Data.Text qualified as Text
 import Foreign.ForeignPtr (touchForeignPtr)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import Foreign.Ptr (minusPtr, plusPtr)
@@ -329,6 +331,13 @@ chr4 ba# offset# firstWord# =
 word8ToInt# :: Word8# -> Int#
 word8ToInt# word8 =
   int8ToInt# (word8ToInt8# word8)
+
+-- TO TEXT
+
+toText :: Utf8 t -> Text.Text
+toText =
+  -- This could most certainly be optimized for better performance
+  Text.pack . toChars
 
 -- TO BUILDER
 

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -22,10 +22,12 @@ import Data.Maybe qualified as Maybe
 import Data.Name (Name)
 import Data.Semigroup (sconcat)
 import Data.Utf8 qualified as Utf8
+import Gren.Int qualified as GI
 import Parse.Primitives qualified as P
 import Reporting.Annotation qualified as A
 import Text.PrettyPrint.Avh4.Block (Block)
 import Text.PrettyPrint.Avh4.Block qualified as Block
+import Text.Printf qualified
 
 toByteStringBuilder :: Src.Module -> B.Builder
 toByteStringBuilder module_ =
@@ -557,10 +559,8 @@ formatExpr = \case
   Src.Str string ->
     NoExpressionParens $
       formatString StringStyleSingleQuoted string
-  Src.Int int ->
-    NoExpressionParens $
-      Block.line $
-        Block.string7 (show int)
+  Src.Int int intFormat ->
+    NoExpressionParens $ formatInt intFormat int
   Src.Float float ->
     NoExpressionParens $
       Block.line $
@@ -787,6 +787,16 @@ formatExpr = \case
       parensComments commentsBefore commentsAfter $
         exprParensNone $
           formatExpr (A.toValue expr)
+
+formatInt :: GI.IntFormat -> Int -> Block
+formatInt intFormat int =
+  case intFormat of
+    GI.DecimalInt ->
+      Block.line $
+        Block.string7 (show int)
+    GI.HexInt ->
+      Block.line $
+        Block.string7 (Text.Printf.printf "0x%X" int)
 
 parensComments :: [Src.Comment] -> [Src.Comment] -> Block -> Block
 parensComments [] [] inner = inner
@@ -1023,10 +1033,8 @@ formatPattern = \case
   Src.PStr string ->
     NoPatternParens $
       formatString StringStyleSingleQuoted string
-  Src.PInt int ->
-    NoPatternParens $
-      Block.line $
-        Block.string7 (show int)
+  Src.PInt int intFormat ->
+    NoPatternParens $ formatInt intFormat int
 
 formatPatternConstructorArg :: ([Src.Comment], Src.Pattern) -> PatternBlock
 formatPatternConstructorArg (commentsBefore, pat) =

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -359,17 +359,23 @@ formatExposed = \case
 formatImport :: ([Src.Comment], Src.Import) -> Block
 formatImport (commentsBefore, Src.Import name alias exposing exposingComments comments) =
   let (SC.ImportComments commentsAfterKeyword commentsAfterName) = comments
-   in spaceOrIndent $
+   in Block.stack $
         NonEmpty.fromList $
           catMaybes
-            [ Just $ Block.line $ Block.string7 "import",
-              Just $ withCommentsBefore commentsAfterKeyword $ Block.line $ utf8 $ A.toValue name,
-              (spaceOrStack . fmap formatComment) <$> NonEmpty.nonEmpty commentsAfterName,
-              fmap formatImportAlias alias,
-              formatExposing
-                (maybe [] SC._afterExposing exposingComments)
-                (maybe [] SC._afterExposingListing exposingComments)
-                exposing
+            [ fmap (\b -> Block.stack [Block.blankLine, b]) $ formatCommentBlock commentsBefore,
+              Just $
+                spaceOrIndent $
+                  NonEmpty.fromList $
+                    catMaybes
+                      [ Just $ Block.line $ Block.string7 "import",
+                        Just $ withCommentsBefore commentsAfterKeyword $ Block.line $ utf8 $ A.toValue name,
+                        (spaceOrStack . fmap formatComment) <$> NonEmpty.nonEmpty commentsAfterName,
+                        fmap formatImportAlias alias,
+                        formatExposing
+                          (maybe [] SC._afterExposing exposingComments)
+                          (maybe [] SC._afterExposingListing exposingComments)
+                          exposing
+                      ]
             ]
 
 formatImportAlias :: (Name, SC.ImportAliasComments) -> Block

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -202,7 +202,7 @@ formatCommentBlockNonEmpty =
   spaceOrStack . fmap formatComment
 
 formatModule :: Src.Module -> Block
-formatModule (Src.Module moduleName exports docs imports values unions aliases binops topLevelComments comments effects) =
+formatModule (Src.Module moduleName exports docs imports values unions aliases (commentsBeforeBinops, binops) topLevelComments comments effects) =
   Block.stack $
     NonEmpty.fromList $
       catMaybes
@@ -279,10 +279,21 @@ formatModule (Src.Module moduleName exports docs imports values unions aliases b
         Nothing -> Nothing
         Just some ->
           Just $
-            Block.stack
-              [ Block.blankLine,
-                Block.stack $ fmap (formatInfix . A.toValue) some
-              ]
+            Block.stack $
+              NonEmpty.fromList $
+                mconcat
+                  [ case formatCommentBlock commentsBeforeBinops of
+                      Just comments_ ->
+                        [ Block.blankLine,
+                          Block.blankLine,
+                          comments_,
+                          Block.blankLine
+                        ]
+                      Nothing -> [],
+                    [ Block.blankLine,
+                      Block.stack $ fmap (formatInfix . A.toValue) some
+                    ]
+                  ]
 
 formatTopLevelCommentBlock :: NonEmpty Src.Comment -> Block
 formatTopLevelCommentBlock comments =

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -352,7 +352,8 @@ formatExposing commentsAfterKeyword commentsAfterListing = \case
 formatExposed :: Src.Exposed -> Block
 formatExposed = \case
   Src.Lower name -> Block.line $ utf8 $ A.toValue name
-  Src.Upper name privacy -> Block.line $ utf8 $ A.toValue name
+  Src.Upper name Src.Private -> Block.line $ utf8 (A.toValue name)
+  Src.Upper name (Src.Public _) -> Block.line $ utf8 (A.toValue name) <> Block.string7 "(..)"
   Src.Operator _ name -> Block.line $ Block.char7 '(' <> utf8 name <> Block.char7 ')'
 
 formatImport :: ([Src.Comment], Src.Import) -> Block

--- a/compiler/src/Gren/Int.hs
+++ b/compiler/src/Gren/Int.hs
@@ -1,0 +1,4 @@
+module Gren.Int (IntFormat (..)) where
+
+data IntFormat = DecimalInt | HexInt
+  deriving (Show)

--- a/compiler/src/Gren/String.hs
+++ b/compiler/src/Gren/String.hs
@@ -5,6 +5,7 @@
 
 module Gren.String
   ( String,
+    StringFormat (..),
     toChars,
     fromChars,
     toBuilder,
@@ -30,6 +31,11 @@ type String =
   Utf8.Utf8 GREN_STRING
 
 data GREN_STRING
+
+data StringFormat
+  = SingleLineString
+  | MultilineString
+  deriving (Show)
 
 -- HELPERS
 

--- a/compiler/src/Parse/Declaration.hs
+++ b/compiler/src/Parse/Declaration.hs
@@ -234,7 +234,7 @@ portDecl maybeDocs =
 
 -- INVARIANT: always chomps to a freshline
 --
-infix_ :: Parser E.Module (A.Located Src.Infix)
+infix_ :: Parser E.Module (A.Located Src.Infix, [Src.Comment])
 infix_ =
   let err = E.Infix
       _err = \_ -> E.Infix
@@ -260,6 +260,6 @@ infix_ =
         Space.chompAndCheckIndent _err err
         name <- Var.lower err
         end <- getPosition
-        Space.chomp _err
+        commentsAfter <- Space.chomp _err
         Space.checkFreshLine err
-        return (A.at start end (Src.Infix op associativity precedence name))
+        return (A.at start end (Src.Infix op associativity precedence name), commentsAfter)

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -44,8 +44,8 @@ term =
 string :: A.Position -> Parser E.Expr Src.Expr
 string start =
   do
-    str <- String.string E.Start E.String
-    addEnd start (Src.Str str)
+    (str, stringFormat) <- String.string E.Start E.String
+    addEnd start (Src.Str str stringFormat)
 
 character :: A.Position -> Parser E.Expr Src.Expr
 character start =

--- a/compiler/src/Parse/Expression.hs
+++ b/compiler/src/Parse/Expression.hs
@@ -59,7 +59,7 @@ number start =
     nmbr <- Number.number E.Start E.Number
     addEnd start $
       case nmbr of
-        Number.Int int -> Src.Int int
+        Number.Int int intFormat -> Src.Int int intFormat
         Number.Float float -> Src.Float float
 
 parenthesizedExpr :: A.Position -> Parser E.Expr Src.Expr

--- a/compiler/src/Parse/Pattern.hs
+++ b/compiler/src/Parse/Pattern.hs
@@ -73,7 +73,7 @@ termHelp start =
               let width = fromIntegral (Utf8.size float)
                in cerr row (col - width) (E.PFloat width),
       do
-        str <- String.string E.PStart E.PString
+        (str, _) <- String.string E.PStart E.PString
         addEnd start (Src.PStr str),
       do
         chr <- String.character E.PStart E.PChar

--- a/compiler/src/Parse/Pattern.hs
+++ b/compiler/src/Parse/Pattern.hs
@@ -66,8 +66,8 @@ termHelp start =
         number <- Number.number E.PStart E.PNumber
         end <- getPosition
         case number of
-          Number.Int int ->
-            return (A.at start end (Src.PInt int))
+          Number.Int int intFormat ->
+            return (A.at start end (Src.PInt int intFormat))
           Number.Float float ->
             P.Parser $ \(P.State _ _ _ _ row col) _ _ cerr _ ->
               let width = fromIntegral (Utf8.size float)

--- a/gren.cabal
+++ b/gren.cabal
@@ -97,6 +97,7 @@ Common gren-common
         Gren.Compiler.Type.Extract
         Gren.Constraint
         Gren.Docs
+        Gren.Int
         Gren.Float
         Gren.Format
         Gren.Format.Normalize

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -347,6 +347,12 @@ spec = do
                                            ]
 
   describe "expressions" $ do
+    describe "int literals" $ do
+      it "formats decimal integers" $
+        ["234"] `shouldFormatExpressionAs` ["234"]
+      it "formats hex integers" $
+        ["0xfa234"] `shouldFormatExpressionAs` ["0xFA234"]
+
     describe "array literals" $ do
       it "formats" $
         ["[1,2,3]"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -127,6 +127,14 @@ spec = do
                            formattedModuleBody
                          ]
 
+    describe "import listings" $ do
+      it "formats" $
+        assertFormatted
+          [ formattedModuleHeader,
+            "import Module1 exposing ( (+), f, T1, T2(..), T3 )",
+            formattedModuleBody
+          ]
+
   describe "top-level definitions" $ do
     it "formats already formatted" $
       assertFormattedModuleBody

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -347,6 +347,31 @@ spec = do
                                            ]
 
   describe "expressions" $ do
+    describe "string literals" $ do
+      it "formats strings" $
+        assertFormattedExpression
+          ["a"]
+      it "formats multiline strings with trimmed whitespace" $
+        assertFormattedModuleBody
+          [ "str =",
+            "    \"\"\"",
+            "    # String",
+            "      - indented more",
+            "    \"\"\""
+          ]
+      it "formats multiline strings" $
+        [ "str = \"\"\"",
+          "  1",
+          "    2",
+          "\"\"\""
+        ]
+          `shouldFormatModuleBodyAs` [ "str =",
+                                       "    \"\"\"",
+                                       "    1",
+                                       "      2",
+                                       "    \"\"\""
+                                     ]
+
     describe "int literals" $ do
       it "formats decimal integers" $
         ["234"] `shouldFormatExpressionAs` ["234"]

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -103,7 +103,6 @@ spec = do
                            formattedModuleBody
                          ]
     it "does not attach unindented comments to the import line" $
-      -- TODO: eventually all these comments should be retained instead of dropped
       [ formattedModuleHeader,
         "import Module1",
         "{-A-}",
@@ -117,8 +116,14 @@ spec = do
       ]
         `shouldFormatAs` [ formattedModuleHeader,
                            "import Module1",
+                           "",
+                           "{- A -}",
                            "import Module2WithAs as M2",
+                           "",
+                           "{- B -}",
                            "import Module3WithExposing exposing (..)",
+                           "",
+                           "{- C -}",
                            "import Module4WithAsAndExposing as M4 exposing (..)",
                            "",
                            "",

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -729,7 +729,7 @@ shouldFormatModuleBodyAs_ projectType inputLines expectedOutputLines =
         Left err ->
           expectationFailure ("shouldFormatModuleBodyAs: failed to format" <> show err)
         Right Nothing ->
-          expectationFailure "shouldFormatModuleBodyAs: internal error: could not strip module header"
+          expectationFailure ("shouldFormatModuleBodyAs: internal error: could not strip module header: " <> show actualOutput)
         Right (Just actualModuleBody) ->
           actualModuleBody `shouldBe` expectedOutput
 


### PR DESCRIPTION
A few various things that seem good to fix before the 0.2 release:

- [x] retain whether or not a custom type's variants are exposed in `exposing` listings
- [x] allow integer literals to retain hexadecimal format
- [x] allow string literals to retain multiline (triple-quoted) string format
  - [x] make sure it works correctly w/r to https://github.com/gren-lang/compiler/pull/151 (though I'm not sure I understand the feature well enough to think of all possible edge cases to consider)
- [x] retain comments before and between `import` statements