### PR TITLE
No caching for local deps

### DIFF
--- a/builder/src/Gren/Details.hs
+++ b/builder/src/Gren/Details.hs
@@ -396,11 +396,15 @@ build key cache depsMVar pkg (Solver.Details vsn maybeLocalPath _) f fs =
                               objects = gatherObjects results
                               artifacts = Artifacts ifaces objects
                               fingerprints = Set.insert f fs
-                           in do
-                                writeDocs packageDir docsStatus results
-                                File.writeBinary path (ArtifactCache fingerprints artifacts)
-                                Reporting.report key Reporting.DBuilt
-                                return (Right artifacts)
+                           in if Maybe.isJust maybeLocalPath
+                                then do
+                                  Reporting.report key Reporting.DBuilt
+                                  return (Right artifacts)
+                                else do
+                                  writeDocs packageDir docsStatus results
+                                  File.writeBinary path (ArtifactCache fingerprints artifacts)
+                                  Reporting.report key Reporting.DBuilt
+                                  return (Right artifacts)
 
 -- GATHER
 

--- a/builder/src/Gren/PossibleFilePath.hs
+++ b/builder/src/Gren/PossibleFilePath.hs
@@ -3,6 +3,7 @@ module Gren.PossibleFilePath
     mapWith,
     encodeJson,
     other,
+    is,
     toChars,
   )
 where
@@ -26,6 +27,12 @@ other possibleFP =
   case possibleFP of
     Is _ -> Nothing
     Other a -> Just a
+
+is :: PossibleFilePath a -> Bool
+is possibleFP =
+  case possibleFP of
+    Is _ -> True
+    Other _ -> False
 
 encodeJson :: (a -> E.Value) -> PossibleFilePath a -> E.Value
 encodeJson encoderForNonFP possibleFP =

--- a/terminal/src/Package/Install.hs
+++ b/terminal/src/Package/Install.hs
@@ -138,7 +138,7 @@ attemptChangesHelp root env skipPrompt oldOutline newOutline question =
                 do
                   Outline.write root oldOutline
                   return (Left exit)
-              Right () ->
+              Right _ ->
                 do
                   putStrLn "Success!"
                   return (Right ())

--- a/terminal/src/Package/Uninstall.hs
+++ b/terminal/src/Package/Uninstall.hs
@@ -139,7 +139,7 @@ attemptChangesHelp root env skipPrompt oldOutline newOutline question =
                 do
                   Outline.write root oldOutline
                   return (Left exit)
-              Right () ->
+              Right _ ->
                 do
                   putStrLn "Success!"
                   return (Right ())


### PR DESCRIPTION
If the project being compiled requires a local dependency, then ignore the cache to make sure the latest changes are compiled. This also disables writing a cache for the dependency in question.

This will always cold compile the local dependency (but fortunetly, other dependencies are still cached). Improvements in this area is left for a future PR.