### PR TITLE
format: Fix unicode escapes in string literals

### DIFF
--- a/compiler/src/Data/Utf8.hs
+++ b/compiler/src/Data/Utf8.hs
@@ -24,6 +24,7 @@ module Data.Utf8
     --
     toChars,
     toText,
+    toShortByteString,
     toBuilder,
     toEscapedBuilder,
     --
@@ -45,6 +46,7 @@ import Data.Binary.Put (putBuilder)
 import Data.Bits (shiftR, (.&.))
 import Data.ByteString.Builder.Internal qualified as B
 import Data.ByteString.Internal qualified as B
+import Data.ByteString.Short qualified as BSS
 import Data.Char qualified as Char
 import Data.List qualified as List
 import Data.Text qualified as Text
@@ -338,6 +340,12 @@ toText :: Utf8 t -> Text.Text
 toText =
   -- This could most certainly be optimized for better performance
   Text.pack . toChars
+
+-- TO BYTESTRING
+
+toShortByteString :: Utf8 t -> BSS.ShortByteString
+toShortByteString (Utf8 bytes) =
+  BSS.SBS bytes
 
 -- TO BUILDER
 

--- a/compiler/src/Gren/Format.hs
+++ b/compiler/src/Gren/Format.hs
@@ -23,8 +23,6 @@ import Data.Maybe (catMaybes, maybeToList)
 import Data.Maybe qualified as Maybe
 import Data.Name (Name)
 import Data.Semigroup (sconcat)
-import Data.Text qualified as Text
-import Data.Text.Encoding (encodeUtf8Builder)
 import Data.Utf8 qualified as Utf8
 import Gren.Int qualified as GI
 import Gren.String qualified as GS

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -350,7 +350,13 @@ spec = do
     describe "string literals" $ do
       it "formats strings" $
         assertFormattedExpression
-          ["a"]
+          ["\"a\""]
+      it "formats escapes" $
+        assertFormattedExpression
+          ["\"\\n\\r\\t\\\"\\'\\\\\""]
+      it "formats unicode escapes" $
+        assertFormattedExpression
+          ["\"A\\u{00A0}B\\u{D83E}\\u{DDDB}C\""]
       it "formats multiline strings with trimmed whitespace" $
         assertFormattedModuleBody
           [ "str =",
@@ -371,6 +377,12 @@ spec = do
                                        "      2",
                                        "    \"\"\""
                                      ]
+      it "formats unicode escapes in multiline strings" $
+        assertFormattedExpression
+          [ "\"\"\"",
+            "A\\u{00A0}B\\u{D83E}\\u{DDDB}C",
+            "\"\"\""
+          ]
 
     describe "int literals" $ do
       it "formats decimal integers" $


### PR DESCRIPTION
Fixes https://github.com/gren-lang/compiler/issues/191

This is a little bit tricky because the AST contains the string values in a format that is optimized for outputting the compiled javascript (it is a fully-assembled `ByteArray#` in UTF8 encoding, with javascript escape sequences, also with unicode escapes normalized to use only 4-digit hex codes).  Perhaps a more ideal option would be to refactor the parser and AST to retain the `String.Chunk`s that are currently used internally in `Gren.String`, but that seemed complicated to do.  So instead this PR just has the formatter try to re-parse the string to recover the information needed to format it properly.

(elm-format hasn't had to deal with this yet, since it is still based on an older version of Elm's parser, so the AST there contains the actual string that is represented, instead of the javascript-escaped version.)