### PR TITLE
Upgrade prettyprint

### DIFF
--- a/gren.cabal
+++ b/gren.cabal
@@ -214,7 +214,7 @@ Common gren-common
         ghc-prim >= 0.5.2,
         haskeline,
         mtl >= 2.2.1 && < 3,
-        prettyprint-avh4 >= 0.1.0.0 && < 0.2,
+        prettyprint-avh4 >= 0.1.1.0 && < 0.2,
         process,
         raw-strings-qq,
         scientific,

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -736,11 +736,11 @@ spec = do
         ["({-A-}Int{-B-})"]
           `shouldFormatTypeAs` ["({- A -} Int {- B -})"]
 
-assertFormatted :: [Text] -> IO ()
+assertFormatted :: (HasCallStack) => [Text] -> IO ()
 assertFormatted lines_ =
   lines_ `shouldFormatAs` lines_
 
-shouldFormatAs :: [Text] -> [Text] -> IO ()
+shouldFormatAs :: (HasCallStack) => [Text] -> [Text] -> IO ()
 shouldFormatAs inputLines expectedOutputLines =
   let input = TE.encodeUtf8 $ Text.unlines inputLines
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
@@ -751,19 +751,19 @@ shouldFormatAs inputLines expectedOutputLines =
         Right actualModuleBody ->
           actualModuleBody `shouldBe` expectedOutput
 
-assertFormattedModuleBody :: [Text] -> IO ()
+assertFormattedModuleBody :: (HasCallStack) => [Text] -> IO ()
 assertFormattedModuleBody lines_ =
   lines_ `shouldFormatModuleBodyAs` lines_
 
-shouldFormatModuleBodyAs :: [Text] -> [Text] -> IO ()
+shouldFormatModuleBodyAs :: (HasCallStack) => [Text] -> [Text] -> IO ()
 shouldFormatModuleBodyAs =
   shouldFormatModuleBodyAs_ Parse.Application
 
-shouldFormatKernelModuleBodyAs :: [Text] -> [Text] -> IO ()
+shouldFormatKernelModuleBodyAs :: (HasCallStack) => [Text] -> [Text] -> IO ()
 shouldFormatKernelModuleBodyAs =
   shouldFormatModuleBodyAs_ (Parse.Package Gren.Package.kernel)
 
-shouldFormatModuleBodyAs_ :: Parse.ProjectType -> [Text] -> [Text] -> IO ()
+shouldFormatModuleBodyAs_ :: (HasCallStack) => Parse.ProjectType -> [Text] -> [Text] -> IO ()
 shouldFormatModuleBodyAs_ projectType inputLines expectedOutputLines =
   let input = TE.encodeUtf8 $ Text.unlines inputLines
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
@@ -776,11 +776,11 @@ shouldFormatModuleBodyAs_ projectType inputLines expectedOutputLines =
         Right (Just actualModuleBody) ->
           actualModuleBody `shouldBe` expectedOutput
 
-assertFormattedExpression :: [Text] -> IO ()
+assertFormattedExpression :: (HasCallStack) => [Text] -> IO ()
 assertFormattedExpression lines_ =
   lines_ `shouldFormatExpressionAs` lines_
 
-shouldFormatExpressionAs :: [Text] -> [Text] -> IO ()
+shouldFormatExpressionAs :: (HasCallStack) => [Text] -> [Text] -> IO ()
 shouldFormatExpressionAs inputLines expectedOutputLines =
   let input = TE.encodeUtf8 $ "expr =\n" <> Text.unlines (fmap ("    " <>) inputLines)
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines
@@ -803,7 +803,7 @@ shouldFormatExpressionAs inputLines expectedOutputLines =
         then Just text
         else LazyText.stripPrefix "    " text
 
-shouldFormatTypeAs :: [Text] -> [Text] -> IO ()
+shouldFormatTypeAs :: (HasCallStack) => [Text] -> [Text] -> IO ()
 shouldFormatTypeAs inputLines expectedOutputLines =
   let input = TE.encodeUtf8 $ "type alias Type =\n" <> Text.unlines (fmap ("    " <>) inputLines)
       expectedOutput = LazyText.unlines $ fmap LazyText.fromStrict expectedOutputLines

--- a/tests/Integration/FormatSpec.hs
+++ b/tests/Integration/FormatSpec.hs
@@ -423,8 +423,7 @@ spec = do
         [ "-(x --A",
           ")"
         ]
-          `shouldFormatExpressionAs` [ "-(x",
-                                       "  -- A",
+          `shouldFormatExpressionAs` [ "-(x -- A",
                                        " )"
                                      ]
 


### PR DESCRIPTION
I published prettyprint-avh4 0.1.1.0 with a bug fix (end-of-line comments are now correctly joined to the preceeding line in some cases where they weren't before) and some added helper functions.  https://hackage.haskell.org/package/prettyprint-avh4-0.1.1.0/changelog

This upgrades to the new version.