### PR TITLE
fix: hint links

### DIFF
--- a/compiler/src/Reporting/Doc.hs
+++ b/compiler/src/Reporting/Doc.hs
@@ -182,11 +182,15 @@ fancyLink word before fileName after =
 
 makeLink :: [Char] -> [Char]
 makeLink fileName =
-  "<https://gren-lang.org/" <> V.toChars V.compiler <> "/" <> fileName <> ">"
+  "<" <> makeNakedLink fileName <> ">"
 
 makeNakedLink :: [Char] -> [Char]
 makeNakedLink fileName =
-  "https://gren-lang.org/" <> V.toChars V.compiler <> "/" <> fileName
+  "https://github.com/gren-lang/compiler/blob/"
+    <> V.toChars V.compiler
+    <> "/hints/"
+    <> fileName
+    <> ".md"
 
 reflowLink :: [Char] -> [Char] -> [Char] -> P.Doc
 reflowLink before fileName after =


### PR DESCRIPTION
Hint links points directly to GitHub file

Previously, hint links were pointing to https://gren-lang.org/0.3.0/imports, which leads to 404. 

Now it points directly to https://github.com/gren-lang/compiler/blob/0.3.0/hints/imports.md