### PR TITLE
Replace Zulip in CONTRIBUTING.md with Discord

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,17 +5,48 @@ to check if the change you're intending to make is a good fit for the project.
 
 We use the `Help Wanted` tag on github issues to indicate that a PR would be
 welcome. If you cannot find an issue for the change you're intending to make,
-head over to our [Zulip](https://gren.zulipchat.com) and start a new topic for your
-idea in either the `#language-design` or `#api-design` streams.
+head over to the Discord server (https://discord.gg/J8aaGMfz).
 
-We like to talk things through before commiting to a change, so that's a good way to go about
-suggesting new features. Also, we're a friendly bunch, so don't be afraid to say hi.
+We're a friendly bunch, so don't be afraid to drop in to say hi or ask questions!
 
-All PRs will be considered, but by going through the above process you increase
-your chances for a merge significantly.
+We also like to talk things through before commiting to a change, so it's a good
+idea to bring up an idea on Discord before making a PR.
+
+[forum-channel-what]: https://support.discord.com/hc/en-us/articles/6208479917079-Forum-Channels-FAQ#h_01G69FJQWTWN88HFEHK7Z6X79N
+
+To do so:
+
+1. Join the Discord server
+2. Find the server's left-hand sidebar
+3. Scroll down to the `Development` category
+4. Choose one of the following [forum channels][forum-channel-what] beneath it:
+
+   * [`#compiler`](https://discord.com/channels/1250584603085766677/1250591099681247332)
+   * [`#language`](https://discord.com/channels/1250584603085766677/1250591320335188099)
+   * [`#core-packages`](https://discord.com/channels/1250584603085766677/1250591260159377490)
+   * [`#www`](https://discord.com/channels/1250584603085766677/1250592392646492283)
+
+5. Make your post:
+
+   * Click in the textbox labelled with 'Search or create a post...'
+   * Enter a title
+   * Follow any additional steps as prompted
+
+
+All PRs will be considered, but going through the above process significantly
+improves your chances of a merge!
 
 ## Local development commands
 
 - build: `cabal build -f dev`
 - run tests: `cabal test -f dev`
 - format files: `ormolu --mode inplace $(git ls-files '*.hs')`
+
+## Back-up / Historic Archives
+
+There's also a [Zulip](https://gren.zulipchat.com) with older
+`#language-design` or `#api-design` streams.
+
+This may act as a fallback for the time being, but it it may be
+sunset since Discord seems preferred.
+


### PR DESCRIPTION
**TL;DR:** Match the doc repo in [replacing Zulip with Discord](https://github.com/gren-lang/gren-lang.github.io/commit/28aa4876942d0ccfe903e7d8567b33e9046c4ab6)

### Changes

* Move Zulip to the bottom of the file as a historic location
* Add Discord Join instructions with links to channels
* Add cross-reference to Discord's limited forum channel documentation
* Various phrasing tweaks