### PR TITLE
Replace help text Zulip references with Discord

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@ lue (lue-bird)
 Allan Clark (allanderek)
 Gaute Berge (gauteab)
 Dimitri B. (BendingBender)
+pushfoo

--- a/hints/port-modules.md
+++ b/hints/port-modules.md
@@ -28,4 +28,4 @@ Our wager with the Gren package ecosystem is that it is better to get a package 
 
 Now this may not be the right choice for your particular project, and that is okay! We will be expanding our core libraries over time, as explained [here](https://github.com/gren-lang/projects/blob/master/roadmap.md#where-is-the-localstorage-package), and we hope you will circle back later to see if Gren has grown into a better fit!
 
-If you have more questions about this choice or what it means for your application, please come ask in [the Gren zulip](https://gren.zulipchat.com/). Folks are friendly and happy to help out! Chances are that a `port` in your application will work great for your case once you learn more about how they are meant to be used.
+If you have more questions about this choice or what it means for your application, please come ask in [the Gren Discord](https://discord.gg/J8aaGMfz). Folks are friendly and happy to help out! Chances are that a `port` in your application will work great for your case once you learn more about how they are meant to be used.

--- a/hints/port-modules.md
+++ b/hints/port-modules.md
@@ -28,4 +28,4 @@ Our wager with the Gren package ecosystem is that it is better to get a package 
 
 Now this may not be the right choice for your particular project, and that is okay! We will be expanding our core libraries over time, as explained [here](https://github.com/gren-lang/projects/blob/master/roadmap.md#where-is-the-localstorage-package), and we hope you will circle back later to see if Gren has grown into a better fit!
 
-If you have more questions about this choice or what it means for your application, please come ask in [the Gren Discord](https://discord.gg/J8aaGMfz). Folks are friendly and happy to help out! Chances are that a `port` in your application will work great for your case once you learn more about how they are meant to be used.
+If you have more questions about this choice or what it means for your application, please come ask the Gren [Discord](https://discord.gg/J8aaGMfz). Folks are friendly and happy to help out! Chances are that a `port` in your application will work great for your case once you learn more about how they are meant to be used.

--- a/terminal/src/Main.hs
+++ b/terminal/src/Main.hs
@@ -60,9 +60,9 @@ outro =
   P.fillSep $
     map P.text $
       words
-        "Be sure to ask on the Gren zulip if you run into trouble! Folks are friendly and\
-        \ happy to help out. They hang out there because it is fun, so be kind to get the\
-        \ best results!"
+        "Be sure to ask on the Gren Discord (https://discord.gg/J8aaGMfz) if you run into trouble!\
+        Folks are friendly and happy to help out. They hang out there because it is fun, so be kind\
+        to get the best results!"
 
 -- INIT
 

--- a/terminal/src/Main.hs
+++ b/terminal/src/Main.hs
@@ -61,8 +61,8 @@ outro =
     map P.text $
       words
         "Be sure to ask on the Gren Discord (https://discord.gg/J8aaGMfz) if you run into trouble!\
-        Folks are friendly and happy to help out. They hang out there because it is fun, so be kind\
-        to get the best results!"
+        \ Folks are friendly and happy to help out. They hang out there because it is fun, so be kind\
+        \ to get the best results!"
 
 -- INIT
 


### PR DESCRIPTION
**TL;DR:** Fix some links I found in help text while causing errors locally :sweat_smile:

### Changes

* Replace Zulip with Discord in hints/port-modules.md
* Replace Zulip with Discord in terminal/src/Main.hs
* Homogenize line length in terminal/src/Main.hs help nudge text