### PR TITLE
Allow CRLF at the start of multiline strings

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Allan Clark (allanderek)
 Gaute Berge (gauteab)
 Dimitri B. (BendingBender)
 pushfoo
+mbartlett21

--- a/compiler/src/Parse/String.hs
+++ b/compiler/src/Parse/String.hs
@@ -118,7 +118,7 @@ finalize start end revChunks =
 dropMultiStringEndingNewline :: [ES.Chunk] -> [ES.Chunk]
 dropMultiStringEndingNewline revChunks =
   case revChunks of
-    (ES.Escape 110) : rest ->
+    (ES.Escape 0x6E) : rest ->
       rest
     _ ->
       revChunks
@@ -215,7 +215,9 @@ multiStringBody leadingWhitespace pos end row col initialPos sr sc revChunks =
             then
               Ok (plusPtr pos 3) row (col + 3) ES.MultilineString $
                 finalize initialPos pos $
-                  dropMultiStringEndingNewline revChunks
+                  if initialPos == pos
+                    then dropMultiStringEndingNewline revChunks
+                    else revChunks {- only trim the last newline -}
             else
               if word == 0x27 {- ' -}
                 then

--- a/compiler/src/Parse/String.hs
+++ b/compiler/src/Parse/String.hs
@@ -195,8 +195,8 @@ multiString pos end row _ _ sr sc =
                             then
                               let !pos2 = plusPtr pos 2
                                in countLeadingWhiteSpaceThenMultiString 0 pos2 end (row + 1) 1 pos2 sr sc
-                          else
-                            Err sr sc E.StringInvalidNewline
+                            else
+                              Err sr sc E.StringInvalidNewline
                 else
                   Err sr sc E.StringMultilineWithoutLeadingNewline
 
@@ -257,7 +257,7 @@ multiStringBody leadingWhitespace pos end row col initialPos sr sc revChunks =
                                     then
                                       let !pos2 = plusPtr pos 2
                                        in dropLeadingWhiteSpaceThenMultiString 0 leadingWhitespace pos2 end (row + 1) 1 pos2 sr sc $
-                                        addEscape newline initialPos pos revChunks
+                                            addEscape newline initialPos pos revChunks
                                     else
                                       Err row col E.StringInvalidNewline
                         else

--- a/compiler/src/Reporting/Error/Syntax.hs
+++ b/compiler/src/Reporting/Error/Syntax.hs
@@ -442,6 +442,7 @@ data String
   | StringEndless_Multi
   | StringEscape Escape
   | StringMultilineWithoutLeadingNewline
+  | StringInvalidNewline
   deriving (Show)
 
 data Escape
@@ -2980,11 +2981,23 @@ toStringReport source string row col =
               source
               region
               Nothing
-              ( D.reflow "The contents of a multiline sting must start on a new line",
+              ( D.reflow "The contents of a multiline string must start on a new line",
                 D.stack
-                  [ D.reflow "Add a \"\"\" a new line right after the opening quotes.",
+                  [ D.reflow "Add a new line right after the opening quotes.",
                     D.toSimpleNote "Here is a valid multi-line string for reference:",
                     D.dullyellow $ D.indent 4 validMultilineStringExample
+                  ]
+              )
+    StringInvalidNewline ->
+      let region = toRegion row col
+       in Report.Report "MULTILINE STRING WITH INVALID NEWLINE" region [] $
+            Code.toSnippet
+              source
+              region
+              Nothing
+              ( D.reflow "New lines in multiline strings must be either \\n or \\r\\n",
+                D.stack
+                  [ D.reflow "Make sure newlines are set to either Windows (\\r\\n) or Unix (\\n)."
                   ]
               )
 

--- a/tests/Parse/MultilineStringSpec.hs
+++ b/tests/Parse/MultilineStringSpec.hs
@@ -21,6 +21,11 @@ spec = do
         "normal string"
         "\"\"\"\nnormal string\"\"\""
 
+    it "no ending newline works" $ do
+      parse
+        "this is \\na test \\nfor newlines"
+        "\"\"\"\nthis is \na test \nfor newlines\"\"\""
+
     it "mixing quotes work" $ do
       parse
         "string with \" in it"

--- a/tests/Parse/MultilineStringSpec.hs
+++ b/tests/Parse/MultilineStringSpec.hs
@@ -21,10 +21,20 @@ spec = do
         "normal string"
         "\"\"\"\nnormal string\"\"\""
 
+    it "crlf regression test" $ do
+      parse
+        "normal string"
+        "\"\"\"\r\nnormal string\"\"\""
+
     it "no ending newline works" $ do
       parse
         "this is \\na test \\nfor newlines"
         "\"\"\"\nthis is \na test \nfor newlines\"\"\""
+
+    it "crlfs work" $ do
+      parse
+        "this is\\na test"
+        "\"\"\"\r\n   this is\r\n   a test\r\n\"\"\""
 
     it "mixing quotes work" $ do
       parse
@@ -41,6 +51,16 @@ spec = do
         "this is\\n a test"
         "\"\"\"\n   this is\n    a test\n\"\"\""
 
+    it "First proper line decides how many spaces to drop for crlf" $ do
+      parse
+        "this is\\n a test"
+        "\"\"\"\r\n   this is\r\n    a test\r\n\"\"\""
+
+    it "Works with differing lines" $ do
+      parse
+        "this is\\n a test"
+        "\"\"\"\n   this is\r\n    a test\n\"\"\""
+
     it "Only leading spaces are dropped" $ do
       parse
         "this is\\na test"
@@ -50,6 +70,16 @@ spec = do
       let isCorrectError ((Error.Syntax.String Error.Syntax.StringMultilineWithoutLeadingNewline _ _)) = True
           isCorrectError _ = False
       Helpers.checkParseError Expression.expression ExpressionBadEnd isCorrectError "\"\"\"this is not allowed\"\"\""
+
+    it "does not allow CR without LF on the first line" $ do
+      let isCorrectError ((Error.Syntax.String Error.Syntax.StringInvalidNewline _ _)) = True
+          isCorrectError _ = False
+      Helpers.checkParseError Expression.expression ExpressionBadEnd isCorrectError "\"\"\"\rthis is not allowed\"\"\""
+
+    it "does not allow CR without LF on the other lines" $ do
+      let isCorrectError ((Error.Syntax.String Error.Syntax.StringInvalidNewline _ _)) = True
+          isCorrectError _ = False
+      Helpers.checkParseError Expression.expression ExpressionBadEnd isCorrectError "\"\"\"\nthis\ris not allowed\"\"\""
 
 parse :: String -> BS.ByteString -> IO ()
 parse expectedStr =


### PR DESCRIPTION
This should fix #254.

I also fixed another bug while I was at it. Gren was silently dropping the last newline if the string didn't end with a newline.