### PR TITLE
Make sure to include last line of source mappings.

### DIFF
--- a/compiler/src/Generate/SourceMap.hs
+++ b/compiler/src/Generate/SourceMap.hs
@@ -86,7 +86,7 @@ mappingMapUpdater toInsert maybeVal =
 
 parseMappingsHelp :: Word16 -> Word16 -> Map Word16 [JS.Mapping] -> Mappings -> Mappings
 parseMappingsHelp currentLine lastLine mappingMap acc =
-  if currentLine >= lastLine
+  if currentLine > lastLine
     then acc
     else case Map.lookup currentLine mappingMap of
       Nothing ->


### PR DESCRIPTION
Ahh, the infamous off-by-one-error 🤦 