### PR TITLE
Replace `gren install` with `gren package install` in import error message

### DIFF
--- a/compiler/src/Reporting/Error/Import.hs
+++ b/compiler/src/Reporting/Error/Import.hs
@@ -72,7 +72,7 @@ toReport source (Error region name unimportedModules problem) =
                         D.fromChars (Pkg.toChars dependency),
                         "package?",
                         "Running",
-                        D.green (D.fromChars ("gren install " ++ Pkg.toChars dependency)),
+                        D.green (D.fromChars ("gren package install " ++ Pkg.toChars dependency)),
                         "should",
                         "make",
                         "it",


### PR DESCRIPTION
I discovered this issue while working on a detailed tutorial that uses the compiler errors to drive development.