### PR TITLE
Let `gren run` use color

### DIFF
--- a/src/Main.gren
+++ b/src/Main.gren
@@ -518,6 +518,7 @@ parseUserArgs model compilerPath =
                     Terminal.Run.make
                         { fsPermission = model.fsPermission
                         , cpPermission = model.cpPermission
+                        , useColor = model.useColor
                         , compilerPath = compilerPath
                         , pathToString = model.pathToString
                         , moduleName = moduleName

--- a/src/Terminal/Run.gren
+++ b/src/Terminal/Run.gren
@@ -28,6 +28,7 @@ type Error
 type alias MakeConfig msg =
     { fsPermission : FileSystem.Permission
     , cpPermission : ChildProcess.Permission
+    , useColor : Bool
     , compilerPath : Path
     , pathToString : Path -> String
     , moduleName : ModuleName
@@ -56,8 +57,8 @@ make config =
                         PackageInstall.run
                             { fsPermission = config.fsPermission
                             , cpPermission = config.cpPermission
+                            , useColor = config.useColor
                             , interactive = False
-                            , useColor = False
                             , stdout = nullStream |> Stream.writable
                             , stdin = nullStream |> Stream.readable
                             }
@@ -91,7 +92,7 @@ make config =
         compile outputPath encodedCommand_ =
             Compiler.Backend.run
                 config.cpPermission
-                { useColor = False
+                { useColor = config.useColor
                 , compilerPath = config.compilerPath
                 , pathToString = config.pathToString
                 , onInit = 


### PR DESCRIPTION
Without this, compile errors don't have color.