### PR TITLE
Fix gren paths showing wrong path for backend binary when overriden.

### DIFF
--- a/src/Main.gren
+++ b/src/Main.gren
@@ -122,7 +122,13 @@ init env =
                 , interactive = interactiveTerminal
                 , useColor = useColor
                 , cacheRoot = cacheRoot
-                , backendPath = backendBinary
+                , backendPath =
+                    when maybePaths is
+                        Just paths ->
+                            paths.localPath
+
+                        Nothing ->
+                            backendBinary
                 , fsPermission = fsPermission
                 , cpPermission = cpPermission
                 , httpPermission = httpPermission

--- a/src/Terminal/PackageInstall.gren
+++ b/src/Terminal/PackageInstall.gren
@@ -643,7 +643,7 @@ prettifyError error =
                 (Just path)
                 (PP.verticalBlock
                     [ PP.block
-                        [ PP.words ("An error occured while I was loading the bundle for "
+                        [ PP.words "An error occured while I was loading the bundle for "
                         , PP.text (" " ++ PackageName.toString package)
                             |> PP.color PP.Green
                         , PP.text "."


### PR DESCRIPTION
Fixes #302 