### PR TITLE
Add NO_SIDE_EFFECT annotation above F[2-9] and A[2-9] functions

### DIFF
--- a/compiler/src/Generate/JavaScript/Functions.hs
+++ b/compiler/src/Generate/JavaScript/Functions.hs
@@ -21,36 +21,43 @@ function F(arity, fun, wrapper) {
   return wrapper;
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 function F2(fun) {
   return F(2, fun, function(a) { return function(b) { return fun(a,b); }; })
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F3(fun) {
   return F(3, fun, function(a) {
     return function(b) { return function(c) { return fun(a, b, c); }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F4(fun) {
   return F(4, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return fun(a, b, c, d); }; }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F5(fun) {
   return F(5, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return function(e) { return fun(a, b, c, d, e); }; }; }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F6(fun) {
   return F(6, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return function(e) { return function(f) {
     return fun(a, b, c, d, e, f); }; }; }; }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F7(fun) {
   return F(7, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return function(e) { return function(f) {
     return function(g) { return fun(a, b, c, d, e, f, g); }; }; }; }; }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F8(fun) {
   return F(8, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return function(e) { return function(f) {
@@ -58,6 +65,7 @@ function F8(fun) {
     return fun(a, b, c, d, e, f, g, h); }; }; }; }; }; }; };
   });
 }
+/* @__NO_SIDE_EFFECTS__ */
 function F9(fun) {
   return F(9, fun, function(a) { return function(b) { return function(c) {
     return function(d) { return function(e) { return function(f) {
@@ -66,27 +74,35 @@ function F9(fun) {
   });
 }
 
+/* @__NO_SIDE_EFFECTS__ */
 function A2(fun, a, b) {
   return fun.a === 2 ? fun.f(a, b) : fun(a)(b);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A3(fun, a, b, c) {
   return fun.a === 3 ? fun.f(a, b, c) : fun(a)(b)(c);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A4(fun, a, b, c, d) {
   return fun.a === 4 ? fun.f(a, b, c, d) : fun(a)(b)(c)(d);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A5(fun, a, b, c, d, e) {
   return fun.a === 5 ? fun.f(a, b, c, d, e) : fun(a)(b)(c)(d)(e);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A6(fun, a, b, c, d, e, f) {
   return fun.a === 6 ? fun.f(a, b, c, d, e, f) : fun(a)(b)(c)(d)(e)(f);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A7(fun, a, b, c, d, e, f, g) {
   return fun.a === 7 ? fun.f(a, b, c, d, e, f, g) : fun(a)(b)(c)(d)(e)(f)(g);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A8(fun, a, b, c, d, e, f, g, h) {
   return fun.a === 8 ? fun.f(a, b, c, d, e, f, g, h) : fun(a)(b)(c)(d)(e)(f)(g)(h);
 }
+/* @__NO_SIDE_EFFECTS__ */
 function A9(fun, a, b, c, d, e, f, g, h, i) {
   return fun.a === 9 ? fun.f(a, b, c, d, e, f, g, h, i) : fun(a)(b)(c)(d)(e)(f)(g)(h)(i);
 }


### PR DESCRIPTION
This improves deadd-code elimination when compiled code is post-processed by vite/rollup.

Fixes #324 