### PR TITLE
One-line error messages from the compiler front end need new-line

### DIFF
--- a/src/Main.gren
+++ b/src/Main.gren
@@ -342,10 +342,6 @@ parseUserArgs model compilerPath =
                 |> Stream.Log.string model.stderr
                 |> Task.map (\_ -> Task.execute <| Node.exitWithCode 1)
 
-        endWithErrorLine stringErr =
-            Stream.Log.line model.stderr stringErr
-                |> Task.map (\_ -> Task.execute <| Node.exitWithCode 1)
-
         endWithErrorString stringErr =
             Stream.Log.string model.stderr stringErr
                 |> Task.map (\_ -> Task.execute <| Node.exitWithCode 1)
@@ -356,7 +352,7 @@ parseUserArgs model compilerPath =
     in
     when CLI.Parser.run model.args CliParser.parser is
         CLI.Parser.UnknownCommand commandName ->
-            endWithErrorLine ("I don't recognize this command: " ++ commandName)
+            endWithErrorString ("I don't recognize this command: " ++ commandName ++ "\n")
                 |> Task.perform RunCmd
     
         CLI.Parser.BadFlags err ->


### PR DESCRIPTION
When the gren compiler front end reports a simple one line error message for "I don't recognize this command", it fails to terminate the output with a newline character.

This change adds a new helper function, endErrorWithLine, which uses Stream.Log.line, to avoid changing other existing usages of endErrorWithString.

Before this change, my shell (zsh on Linux), shows the lack of newline:
<img width="336" height="42" alt="image" src="https://github.com/user-attachments/assets/20b499c5-4aa3-407f-ba37-1245749528e4" />

After this change, there's a newline:
<img width="324" height="51" alt="image" src="https://github.com/user-attachments/assets/87111f0f-693d-4269-871a-2d3475bbfb34" />
