### PR TITLE
Automatically upload build artifacts on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  release:
+    types: [published]
 
 env:
   ghc: "9.10.3"
@@ -47,7 +49,7 @@ jobs:
             artifact: gren_linux
           - runner: ubuntu-24.04-arm
             arch: aarch64
-            artifact: gren_linux_arm64
+            artifact: gren_linux_aarch64
 
     runs-on: ${{ matrix.runner }}
 
@@ -121,7 +123,11 @@ jobs:
     needs: validate-code-formatting
     strategy:
       matrix:
-        os: [macos-15, macos-15-intel]
+        include:
+          - os: macos-15
+            artifact: gren_mac_aarch64
+          - os: macos-15-intel
+            artifact: gren_mac
 
     runs-on: ${{ matrix.os }}
 
@@ -175,7 +181,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: gren-${{ matrix.os }}
+          name: ${{ matrix.artifact }}
           path: gren
           retention-days: 14
 
@@ -234,3 +240,35 @@ jobs:
           name: gren.exe
           path: gren
           retention-days: 14
+
+  publish-release:
+    needs: [linux, mac, windows]
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage release assets
+        run: |
+          set -eux
+          mkdir release-assets
+          for name in gren_linux gren_linux_aarch64 gren_mac gren_mac_aarch64 gren.exe; do
+            cp "artifacts/$name/gren" "release-assets/$name"
+          done
+
+      - name: Upload assets to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          cd release-assets
+          gh release upload "$TAG" \
+            gren_linux gren_linux_aarch64 gren_mac gren_mac_aarch64 gren.exe \
+            --clobber


### PR DESCRIPTION
When you create a release in github, this will trigger an action that downloads and uploads the assets to the release.